### PR TITLE
Added storage::base64 with some fun message helpers

### DIFF
--- a/packages/serialization/Cargo.toml
+++ b/packages/serialization/Cargo.toml
@@ -3,11 +3,17 @@ name = "secret-toolkit-serialization"
 version = "0.1.0"
 edition = "2018"
 
+[features]
+default = ["json", "bincode2", "base64"]
+json = []
+base64 = ["schemars"]
+
 [dependencies]
 serde = "1.0"
 bincode2 = { version = "2.0", optional = true }
 cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.0" }
+schemars = { version = "0", optional = true }
 
-[features]
-default = ["json", "bincode2"]
-json = []
+[dev-dependencies]
+serde_json = "1"
+cosmwasm-schema = { version = "0.9.2" }

--- a/packages/serialization/Cargo.toml
+++ b/packages/serialization/Cargo.toml
@@ -9,5 +9,6 @@ bincode2 = { version = "2.0", optional = true }
 cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.0" }
 
 [features]
-default = ["json", "bincode2"]
+default = ["json", "bincode2", "base64"]
 json = []
+base64 = []

--- a/packages/serialization/Cargo.toml
+++ b/packages/serialization/Cargo.toml
@@ -9,6 +9,5 @@ bincode2 = { version = "2.0", optional = true }
 cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.0" }
 
 [features]
-default = ["json", "bincode2", "base64"]
+default = ["json", "bincode2"]
 json = []
-base64 = []

--- a/packages/serialization/src/base64.rs
+++ b/packages/serialization/src/base64.rs
@@ -55,7 +55,6 @@ impl<Ser: crate::Serde, T: ser::Serialize> ser::Serialize for Base64Of<Ser, T> {
             Ok(b) => Binary(b).to_base64(),
             Err(err) => return Err(<S::Error as ser::Error>::custom(err)),
         };
-        println!("{}", string);
         serializer.serialize_str(&string)
     }
 }

--- a/packages/serialization/src/base64.rs
+++ b/packages/serialization/src/base64.rs
@@ -5,6 +5,8 @@ use serde::{de, ser};
 
 use cosmwasm_std::Binary;
 
+use crate::Serde;
+
 /// Alias of `cosmwasm_std::Binary` for better naming
 pub type Base64 = Binary;
 
@@ -14,7 +16,7 @@ pub type Base64 = Binary;
 /// example in the `msg` field of the `Receive` interface, to remove the
 /// boilerplate of serializing or deserializing the `Binary` to the relevant
 /// type `T`.
-pub struct Base64Of<S: crate::Serde, T> {
+pub struct Base64Of<S: Serde, T> {
     // This is pub so that users can easily unwrap this if needed,
     // or just swap the entire instance.
     pub inner: T,
@@ -27,7 +29,7 @@ pub type Base64JsonOf<T> = Base64Of<crate::Json, T>;
 #[cfg(feature = "bincode2")]
 pub type Base64Bincode2Of<T> = Base64Of<crate::Bincode2, T>;
 
-impl<S: crate::Serde, T> From<T> for Base64Of<S, T> {
+impl<S: Serde, T> From<T> for Base64Of<S, T> {
     fn from(other: T) -> Self {
         Self {
             inner: other,
@@ -36,20 +38,20 @@ impl<S: crate::Serde, T> From<T> for Base64Of<S, T> {
     }
 }
 
-impl<S: crate::Serde, T> std::ops::Deref for Base64Of<S, T> {
+impl<S: Serde, T> std::ops::Deref for Base64Of<S, T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
 
-impl<S: crate::Serde, T> std::ops::DerefMut for Base64Of<S, T> {
+impl<S: Serde, T> std::ops::DerefMut for Base64Of<S, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
 }
 
-impl<Ser: crate::Serde, T: ser::Serialize> ser::Serialize for Base64Of<Ser, T> {
+impl<Ser: Serde, T: ser::Serialize> ser::Serialize for Base64Of<Ser, T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: ser::Serializer,
@@ -62,9 +64,7 @@ impl<Ser: crate::Serde, T: ser::Serialize> ser::Serialize for Base64Of<Ser, T> {
     }
 }
 
-impl<'de, S: crate::Serde, T: for<'des> de::Deserialize<'des>> de::Deserialize<'de>
-    for Base64Of<S, T>
-{
+impl<'de, S: Serde, T: for<'des> de::Deserialize<'des>> de::Deserialize<'de> for Base64Of<S, T> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: de::Deserializer<'de>,
@@ -73,12 +73,12 @@ impl<'de, S: crate::Serde, T: for<'des> de::Deserialize<'des>> de::Deserialize<'
     }
 }
 
-struct Base64TVisitor<S: crate::Serde, T> {
+struct Base64TVisitor<S: Serde, T> {
     inner: PhantomData<T>,
     ser: PhantomData<S>,
 }
 
-impl<S: crate::Serde, T> Base64TVisitor<S, T> {
+impl<S: Serde, T> Base64TVisitor<S, T> {
     fn new() -> Self {
         Self {
             inner: PhantomData,
@@ -87,9 +87,7 @@ impl<S: crate::Serde, T> Base64TVisitor<S, T> {
     }
 }
 
-impl<'de, S: crate::Serde, T: for<'des> de::Deserialize<'des>> de::Visitor<'de>
-    for Base64TVisitor<S, T>
-{
+impl<'de, S: Serde, T: for<'des> de::Deserialize<'des>> de::Visitor<'de> for Base64TVisitor<S, T> {
     type Value = Base64Of<S, T>;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -119,15 +117,18 @@ mod passthrough_impls {
     use std::hash::{Hash, Hasher};
     use std::marker::PhantomData;
 
-    use schemars::JsonSchema;
-
-    use super::Base64Of;
-    use cosmwasm_std::Binary;
     use schemars::gen::SchemaGenerator;
     use schemars::schema::Schema;
+    use schemars::JsonSchema;
+
+    use cosmwasm_std::Binary;
+
+    use crate::Serde;
+
+    use super::Base64Of;
 
     // Clone
-    impl<S: crate::Serde, T: Clone> Clone for Base64Of<S, T> {
+    impl<S: Serde, T: Clone> Clone for Base64Of<S, T> {
         fn clone(&self) -> Self {
             Self {
                 inner: self.inner.clone(),
@@ -137,32 +138,30 @@ mod passthrough_impls {
     }
 
     // Copy
-    impl<S: crate::Serde, T: Copy> Copy for Base64Of<S, T> {}
+    impl<S: Serde, T: Copy> Copy for Base64Of<S, T> {}
 
     // Debug
-    impl<S: crate::Serde, T: Debug> Debug for Base64Of<S, T> {
+    impl<S: Serde, T: Debug> Debug for Base64Of<S, T> {
         fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
             self.inner.fmt(f)
         }
     }
 
     // Display
-    impl<S: crate::Serde, T: Display> Display for Base64Of<S, T> {
+    impl<S: Serde, T: Display> Display for Base64Of<S, T> {
         fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
             self.inner.fmt(f)
         }
     }
 
     // PartialEq
-    impl<S: crate::Serde, S2: crate::Serde, T: PartialEq> PartialEq<Base64Of<S2, T>>
-        for Base64Of<S, T>
-    {
+    impl<S: Serde, S2: Serde, T: PartialEq> PartialEq<Base64Of<S2, T>> for Base64Of<S, T> {
         fn eq(&self, other: &Base64Of<S2, T>) -> bool {
             self.inner.eq(&other.inner)
         }
     }
 
-    impl<S: crate::Serde, T: PartialEq> PartialEq<T> for Base64Of<S, T> {
+    impl<S: Serde, T: PartialEq> PartialEq<T> for Base64Of<S, T> {
         fn eq(&self, other: &T) -> bool {
             self.inner.eq(other)
         }
@@ -175,18 +174,16 @@ mod passthrough_impls {
     // covers that case already. Basically it doesn't understand that S1 and S2
     // _can_ be the same type.
     //
-    // impl<S: crate::Serde, T: Eq> Eq for Base64Of<S, T> {}
+    // impl<S: Serde, T: Eq> Eq for Base64Of<S, T> {}
 
     // PartialOrd
-    impl<S: crate::Serde, S2: crate::Serde, T: PartialOrd> PartialOrd<Base64Of<S2, T>>
-        for Base64Of<S, T>
-    {
+    impl<S: Serde, S2: Serde, T: PartialOrd> PartialOrd<Base64Of<S2, T>> for Base64Of<S, T> {
         fn partial_cmp(&self, other: &Base64Of<S2, T>) -> Option<Ordering> {
             self.inner.partial_cmp(&other.inner)
         }
     }
 
-    impl<S: crate::Serde, T: PartialOrd> PartialOrd<T> for Base64Of<S, T> {
+    impl<S: Serde, T: PartialOrd> PartialOrd<T> for Base64Of<S, T> {
         fn partial_cmp(&self, other: &T) -> Option<Ordering> {
             self.inner.partial_cmp(other)
         }
@@ -196,14 +193,14 @@ mod passthrough_impls {
     // This can not be implemented for the same reason that `Eq` can't be implemented.
 
     // Hash
-    impl<S: crate::Serde, T: Hash> Hash for Base64Of<S, T> {
+    impl<S: Serde, T: Hash> Hash for Base64Of<S, T> {
         fn hash<H: Hasher>(&self, state: &mut H) {
             self.inner.hash(state)
         }
     }
 
     // Default
-    impl<S: crate::Serde, T: Default> Default for Base64Of<S, T> {
+    impl<S: Serde, T: Default> Default for Base64Of<S, T> {
         fn default() -> Self {
             Self {
                 inner: T::default(),
@@ -213,7 +210,7 @@ mod passthrough_impls {
     }
 
     // JsonSchema
-    impl<S: crate::Serde, T: JsonSchema> JsonSchema for Base64Of<S, T> {
+    impl<S: Serde, T: JsonSchema> JsonSchema for Base64Of<S, T> {
         fn schema_name() -> String {
             Binary::schema_name()
         }
@@ -226,10 +223,10 @@ mod passthrough_impls {
 
 #[cfg(test)]
 mod test {
-    use cosmwasm_schema::schema_for;
     use schemars::JsonSchema;
     use serde::{Deserialize, Serialize};
 
+    use cosmwasm_schema::schema_for;
     use cosmwasm_std::{Binary, StdResult};
 
     use crate::base64::Base64JsonOf;

--- a/packages/serialization/src/base64.rs
+++ b/packages/serialization/src/base64.rs
@@ -1,0 +1,279 @@
+use std::fmt;
+use std::marker::PhantomData;
+
+use serde::{de, ser};
+
+use cosmwasm_std::Binary;
+
+/// Alias of `cosmwasm_std::Binary` for better naming
+pub type Base64 = Binary;
+
+/// A wrapper that automatically deserializes base64 strings to one of the
+/// `Serde` types.
+#[derive()]
+pub struct Base64Of<S: crate::Serde, T> {
+    // This is pub so that users can easily unwrap this if needed,
+    // or just swap the entire instance.
+    pub inner: T,
+    ser: PhantomData<S>,
+}
+
+#[cfg(feature = "json")]
+pub type Base64JsonOf<T> = Base64Of<crate::Json, T>;
+
+#[cfg(feature = "bincode2")]
+pub type Base64Bincode2Of<T> = Base64Of<crate::Bincode2, T>;
+
+impl<S: crate::Serde, T> From<T> for Base64Of<S, T> {
+    fn from(other: T) -> Self {
+        Self {
+            inner: other,
+            ser: PhantomData,
+        }
+    }
+}
+
+impl<S: crate::Serde, T> std::ops::Deref for Base64Of<S, T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<S: crate::Serde, T> std::ops::DerefMut for Base64Of<S, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+impl<Ser: crate::Serde, T: ser::Serialize> ser::Serialize for Base64Of<Ser, T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: ser::Serializer,
+    {
+        let string = match Ser::serialize(&self.inner) {
+            Ok(b) => Binary(b).to_base64(),
+            Err(err) => return Err(<S::Error as ser::Error>::custom(err)),
+        };
+        println!("{}", string);
+        serializer.serialize_str(&string)
+    }
+}
+
+impl<'de, S: crate::Serde, T: for<'des> de::Deserialize<'des>> de::Deserialize<'de>
+    for Base64Of<S, T>
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        deserializer.deserialize_str(Base64TVisitor::<S, T>::new())
+    }
+}
+
+struct Base64TVisitor<S: crate::Serde, T> {
+    inner: PhantomData<T>,
+    ser: PhantomData<S>,
+}
+
+impl<S: crate::Serde, T> Base64TVisitor<S, T> {
+    fn new() -> Self {
+        Self {
+            inner: PhantomData,
+            ser: PhantomData,
+        }
+    }
+}
+
+impl<'de, S: crate::Serde, T: for<'des> de::Deserialize<'des>> de::Visitor<'de>
+    for Base64TVisitor<S, T>
+{
+    type Value = Base64Of<S, T>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("valid base64 encoded string")
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let binary = Base64::from_base64(v).map_err(|_| {
+            //
+            E::custom(format!("invalid base64: {}", v))
+        })?;
+        match S::deserialize::<T>(binary.as_slice()) {
+            Ok(val) => Ok(Base64Of::from(val)),
+            Err(err) => Err(E::custom(err)),
+        }
+    }
+}
+
+/// These traits are conditionally implemented for Base64Of<S, T>
+/// if T implements the trait being implemented.
+mod passthrough_impls {
+    use std::fmt::{Debug, Display, Formatter};
+    use std::marker::PhantomData;
+
+    use super::Base64Of;
+    use std::cmp::Ordering;
+    use std::hash::{Hash, Hasher};
+
+    // Clone
+    impl<S: crate::Serde, T: Clone> Clone for Base64Of<S, T> {
+        fn clone(&self) -> Self {
+            Self {
+                inner: self.inner.clone(),
+                ser: self.ser,
+            }
+        }
+    }
+
+    // Copy
+    impl<S: crate::Serde, T: Copy> Copy for Base64Of<S, T> {}
+
+    // Debug
+    impl<S: crate::Serde, T: Debug> Debug for Base64Of<S, T> {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            self.inner.fmt(f)
+        }
+    }
+
+    // Display
+    impl<S: crate::Serde, T: Display> Display for Base64Of<S, T> {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            self.inner.fmt(f)
+        }
+    }
+
+    // PartialEq
+    impl<S: crate::Serde, S2: crate::Serde, T: PartialEq> PartialEq<Base64Of<S2, T>>
+        for Base64Of<S, T>
+    {
+        fn eq(&self, other: &Base64Of<S2, T>) -> bool {
+            self.inner.eq(&other.inner)
+        }
+    }
+
+    impl<S: crate::Serde, T: PartialEq> PartialEq<T> for Base64Of<S, T> {
+        fn eq(&self, other: &T) -> bool {
+            self.inner.eq(other)
+        }
+    }
+
+    // Eq
+    // This implementation is not possible because the `S: Ser` type parameter
+    // shouldn't matter in the `PartialEq` implementation, but `Eq` demands
+    // that Rhs is Self, and Rust doesn't recognize that the `PartialEq` impl
+    // covers that case already. Basically it doesn't understand that S1 and S2
+    // _can_ be the same type.
+    //
+    // impl<S: crate::Serde, T: Eq> Eq for Base64Of<S, T> {}
+
+    // PartialOrd
+    impl<S: crate::Serde, S2: crate::Serde, T: PartialOrd> PartialOrd<Base64Of<S2, T>>
+        for Base64Of<S, T>
+    {
+        fn partial_cmp(&self, other: &Base64Of<S2, T>) -> Option<Ordering> {
+            self.inner.partial_cmp(&other.inner)
+        }
+    }
+
+    impl<S: crate::Serde, T: PartialOrd> PartialOrd<T> for Base64Of<S, T> {
+        fn partial_cmp(&self, other: &T) -> Option<Ordering> {
+            self.inner.partial_cmp(other)
+        }
+    }
+
+    // Ord
+    // This can not be implemented for the same reason that `Eq` can't be implemented.
+
+    // Hash
+    impl<S: crate::Serde, T: Hash> Hash for Base64Of<S, T> {
+        fn hash<H: Hasher>(&self, state: &mut H) {
+            self.inner.hash(state)
+        }
+    }
+
+    // Default
+    impl<S: crate::Serde, T: Default> Default for Base64Of<S, T> {
+        fn default() -> Self {
+            Self {
+                inner: T::default(),
+                ser: PhantomData,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use serde::{Deserialize, Serialize};
+
+    use cosmwasm_std::{Binary, StdResult};
+
+    use crate::base64::Base64JsonOf;
+
+    #[derive(Deserialize, Serialize, PartialEq, Debug)]
+    struct Foo {
+        bar: String,
+        baz: u32,
+    }
+
+    impl Foo {
+        fn new() -> Self {
+            Self {
+                bar: String::from("some stuff"),
+                baz: 234,
+            }
+        }
+    }
+
+    #[derive(Deserialize, Serialize, PartialEq, Debug)]
+    struct Wrapper {
+        inner: Base64JsonOf<Foo>,
+    }
+
+    impl Wrapper {
+        fn new() -> Self {
+            Self {
+                inner: Base64JsonOf::from(Foo::new()),
+            }
+        }
+    }
+
+    #[test]
+    fn test_serialize() -> StdResult<()> {
+        let serialized = cosmwasm_std::to_vec(&Base64JsonOf::from(Foo::new()))?;
+        let serialized2 =
+            cosmwasm_std::to_vec(&Binary::from(b"{\"bar\":\"some stuff\",\"baz\":234}"))?;
+        assert_eq!(
+            br#""eyJiYXIiOiJzb21lIHN0dWZmIiwiYmF6IjoyMzR9""#[..],
+            serialized
+        );
+        assert_eq!(serialized, serialized2);
+
+        let serialized3 = cosmwasm_std::to_vec(&Wrapper::new())?;
+        assert_eq!(
+            br#"{"inner":"eyJiYXIiOiJzb21lIHN0dWZmIiwiYmF6IjoyMzR9"}"#[..],
+            serialized3
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_deserialize() -> StdResult<()> {
+        let obj: Base64JsonOf<Foo> =
+            cosmwasm_std::from_slice(&br#""eyJiYXIiOiJzb21lIHN0dWZmIiwiYmF6IjoyMzR9""#[..])?;
+        assert_eq!(obj, Foo::new());
+
+        let obj2: Wrapper = cosmwasm_std::from_slice(
+            &br#"{"inner":"eyJiYXIiOiJzb21lIHN0dWZmIiwiYmF6IjoyMzR9"}"#[..],
+        )?;
+        assert_eq!(obj2, Wrapper::new());
+        assert_eq!(obj2.inner, Foo::new());
+
+        Ok(())
+    }
+}

--- a/packages/serialization/src/base64.rs
+++ b/packages/serialization/src/base64.rs
@@ -14,7 +14,6 @@ pub type Base64 = Binary;
 /// example in the `msg` field of the `Receive` interface, to remove the
 /// boilerplate of serializing or deserializing the `Binary` to the relevant
 /// type `T`.
-#[derive()]
 pub struct Base64Of<S: crate::Serde, T> {
     // This is pub so that users can easily unwrap this if needed,
     // or just swap the entire instance.

--- a/packages/serialization/src/base64.rs
+++ b/packages/serialization/src/base64.rs
@@ -8,8 +8,12 @@ use cosmwasm_std::Binary;
 /// Alias of `cosmwasm_std::Binary` for better naming
 pub type Base64 = Binary;
 
-/// A wrapper that automatically deserializes base64 strings to one of the
-/// `Serde` types.
+/// A wrapper that automatically deserializes base64 strings to `T` using
+/// one of the `Serde` types.
+/// Use it as a field of your Handle messages (input and output), for
+/// example in the `msg` field of the `Receive` interface, to remove the
+/// boilerplate of serializing or deserializing the `Binary` to the relevant
+/// type `T`.
 #[derive()]
 pub struct Base64Of<S: crate::Serde, T> {
     // This is pub so that users can easily unwrap this if needed,

--- a/packages/serialization/src/lib.rs
+++ b/packages/serialization/src/lib.rs
@@ -2,10 +2,19 @@ use serde::{de::DeserializeOwned, Serialize};
 
 use cosmwasm_std::StdResult;
 
+#[cfg(feature = "base64")]
+mod base64;
 #[cfg(feature = "bincode2")]
 mod bincode2;
 #[cfg(feature = "json")]
 mod json;
+
+#[cfg(feature = "bincode2")]
+pub use crate::base64::Base64Bincode2Of;
+#[cfg(feature = "json")]
+pub use crate::base64::Base64JsonOf;
+#[cfg(feature = "base64")]
+pub use crate::base64::{Base64, Base64Of};
 
 #[cfg(feature = "bincode2")]
 pub use crate::bincode2::Bincode2;

--- a/packages/serialization/src/lib.rs
+++ b/packages/serialization/src/lib.rs
@@ -2,16 +2,18 @@ use serde::{de::DeserializeOwned, Serialize};
 
 use cosmwasm_std::StdResult;
 
+#[cfg(feature = "base64")]
 mod base64;
 #[cfg(feature = "bincode2")]
 mod bincode2;
 #[cfg(feature = "json")]
 mod json;
 
-#[cfg(feature = "bincode2")]
+#[cfg(all(feature = "bincode2", feature = "base64"))]
 pub use crate::base64::Base64Bincode2Of;
-#[cfg(feature = "json")]
+#[cfg(all(feature = "json", feature = "base64"))]
 pub use crate::base64::Base64JsonOf;
+#[cfg(feature = "base64")]
 pub use crate::base64::{Base64, Base64Of};
 
 #[cfg(feature = "bincode2")]

--- a/packages/serialization/src/lib.rs
+++ b/packages/serialization/src/lib.rs
@@ -2,7 +2,6 @@ use serde::{de::DeserializeOwned, Serialize};
 
 use cosmwasm_std::StdResult;
 
-#[cfg(feature = "base64")]
 mod base64;
 #[cfg(feature = "bincode2")]
 mod bincode2;
@@ -13,7 +12,6 @@ mod json;
 pub use crate::base64::Base64Bincode2Of;
 #[cfg(feature = "json")]
 pub use crate::base64::Base64JsonOf;
-#[cfg(feature = "base64")]
 pub use crate::base64::{Base64, Base64Of};
 
 #[cfg(feature = "bincode2")]


### PR DESCRIPTION
This PR adds `secret_toolkit::storage::base64`, and in it:
* `Base64` - Alias for `cosmwasm_std::Binary` (cause this name makes more sense to me)
* `Base64Of<S: secret_toolkit::storage::Serde, T>` - Main feature, explained below
* `Base64JsonOf` - Alias where `S: Json`
* `Base64Bincode2Of` - Alias where `S: Bincode2`

`Base64*Of` is meant to be used as the type of fields in init/handle/query messages of Secret Contracts. When used this way, the field will be expected to be a base64 encoded string of the serialized form of the type `T`, using the chosen serialization method in `S`. The field will behave just like `T` in most contexts, and will the `T` instance will be available under the `.inner` field of the `Base64Of` object. When serializing back to JSON to send the message somewhere, the `Base64Of` field will serialize `inner: T` using the chosen `S` and then encode the result as a base64 string.

This is useful for cases like the `msg` field of contracts that implement the SNIP-20 `Receive` interface.

See the tests at the end of the new module for some usage examples, but in general it allows you to rewrite this:
```Rust
pub enum HandleMsg {
    Receive {
        sender: HumanAddr,
        from: HumanAddr,
        amount: Uint128,
        memo: Option<String>,
        msg: Binary, // interpreted as ReceiveOperation
    },
}
```
to:
```Rust
pub enum HandleMsg {
    Receive {
        sender: HumanAddr,
        from: HumanAddr,
        amount: Uint128,
        memo: Option<String>,
        msg: Base64JsonOf<ReceiveOperation>,
    },
}
```
which would validate the correctness of `msg`, and allow you to directly match on `.msg.inner`