### PR TITLE
Update token permit branch to 1.2.1

### DIFF
--- a/packages/crypto/Cargo.toml
+++ b/packages/crypto/Cargo.toml
@@ -11,7 +11,7 @@ sha2 = { version = "0.9.1", default-features = false }
 libsecp256k1 = { version = "0.3.5", default-features = false, features = [
     "hmac"
 ] }
-cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.2.1" }
+cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.2.3" }
 
 [dev-dependencies]
 secp256k1-test = { package = "secp256k1", version = "0.17", features = [

--- a/packages/crypto/Cargo.toml
+++ b/packages/crypto/Cargo.toml
@@ -11,7 +11,7 @@ sha2 = { version = "0.9.1", default-features = false }
 libsecp256k1 = { version = "0.3.5", default-features = false, features = [
     "hmac"
 ] }
-cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.0" }
+cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.2.1" }
 
 [dev-dependencies]
 secp256k1-test = { package = "secp256k1", version = "0.17", features = [

--- a/packages/incubator/Cargo.toml
+++ b/packages/incubator/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2018"
 [dependencies]
 serde = "1.0"
 siphasher = "0.3.0"
-cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.0" }
-cosmwasm-storage = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.0" }
+cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.2.1" }
+cosmwasm-storage = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.2.1" }
 secret-toolkit-serialization = { path = "../serialization" }

--- a/packages/incubator/Cargo.toml
+++ b/packages/incubator/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2018"
 [dependencies]
 serde = "1.0"
 siphasher = "0.3.0"
-cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.2.1" }
-cosmwasm-storage = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.2.1" }
+cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.2.3" }
+cosmwasm-storage = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.2.3" }
 secret-toolkit-serialization = { path = "../serialization" }

--- a/packages/permit/Cargo.toml
+++ b/packages/permit/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [dependencies]
 serde = "1.0"
-cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.0" }
+cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.2.1" }
 secret-toolkit-utils = { path = "../utils" }
 secret-toolkit-crypto = { path = "../crypto" }
 schemars = "0.7"

--- a/packages/permit/Cargo.toml
+++ b/packages/permit/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [dependencies]
 serde = "1.0"
-cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.2.1" }
+cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.2.3" }
 secret-toolkit-utils = { path = "../utils" }
 secret-toolkit-crypto = { path = "../crypto" }
 schemars = "0.7"

--- a/packages/serialization/Cargo.toml
+++ b/packages/serialization/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 [dependencies]
 serde = "1.0"
 bincode2 = { version = "2.0", optional = true }
-cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.0" }
+cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.2.1" }
 
 [features]
 default = ["json", "bincode2"]

--- a/packages/serialization/Cargo.toml
+++ b/packages/serialization/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 [dependencies]
 serde = "1.0"
 bincode2 = { version = "2.0", optional = true }
-cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.2.1" }
+cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.2.3" }
 
 [features]
 default = ["json", "bincode2"]

--- a/packages/snip20/Cargo.toml
+++ b/packages/snip20/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2018"
 
 [dependencies]
 serde = "1.0"
-cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.0" }
+cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.2.1" }
 secret-toolkit-utils = { path = "../utils" }
 schemars = "0.7"

--- a/packages/snip20/Cargo.toml
+++ b/packages/snip20/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2018"
 
 [dependencies]
 serde = "1.0"
-cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.2.1" }
+cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.2.3" }
 secret-toolkit-utils = { path = "../utils" }
 schemars = "0.7"

--- a/packages/snip721/Cargo.toml
+++ b/packages/snip721/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2018"
 
 [dependencies]
 serde = "1.0"
-cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.0" }
+cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.2.1" }
 secret-toolkit-utils = { path = "../utils" }
 schemars = "0.7"

--- a/packages/snip721/Cargo.toml
+++ b/packages/snip721/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2018"
 
 [dependencies]
 serde = "1.0"
-cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.2.1" }
+cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.2.3" }
 secret-toolkit-utils = { path = "../utils" }
 schemars = "0.7"

--- a/packages/storage/Cargo.toml
+++ b/packages/storage/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2018"
 
 [dependencies]
 serde = "1.0"
-cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.0" }
-cosmwasm-storage = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.0" }
+cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.2.1" }
+cosmwasm-storage = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.2.1" }
 secret-toolkit-serialization = { path = "../serialization" }

--- a/packages/storage/Cargo.toml
+++ b/packages/storage/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2018"
 
 [dependencies]
 serde = "1.0"
-cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.2.1" }
-cosmwasm-storage = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.2.1" }
+cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.2.3" }
+cosmwasm-storage = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.2.3" }
 secret-toolkit-serialization = { path = "../serialization" }

--- a/packages/utils/Cargo.toml
+++ b/packages/utils/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2018"
 [dependencies]
 serde = "1.0"
 schemars = "0.7"
-cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.2.1" }
+cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.2.3" }

--- a/packages/utils/Cargo.toml
+++ b/packages/utils/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2018"
 [dependencies]
 serde = "1.0"
 schemars = "0.7"
-cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.0.0" }
+cosmwasm-std = { git = "https://github.com/enigmampc/SecretNetwork", tag = "v1.2.1" }


### PR DESCRIPTION
Updates cosmwasm-std to 1.2.1, so debug print and query permit toolkit library functions can all live happily together.