### PR TITLE
Generate PrivateKey Idea

### DIFF
--- a/Releses.md
+++ b/Releses.md
@@ -3,6 +3,8 @@
 ## Next Release
 * Added `clear` method to `AppendStore` and `DequeStore` to quickly reset the collections (#34)
 * docs.rs documentation now includes all sub-crates
+* Implemented `rand_core::RngCore` for `secret_toolkit::crypto::Prng`
+* Added `generate` method to `PrivateKey` to generate a keying using a RNG
 
 ## v0.2.0
 This release includes a ton of new features, and a few breaking changes in various interfaces.

--- a/packages/crypto/src/rng.rs
+++ b/packages/crypto/src/rng.rs
@@ -35,6 +35,24 @@ impl Prng {
     }
 }
 
+impl RngCore for Prng {
+    fn next_u32(&mut self) -> u32 {
+        self.rng.next_u32()
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.rng.next_u64()
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        self.rng.fill_bytes(dest)
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
+        self.rng.try_fill_bytes(dest)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Please do not merge this, it's to illustrate an idea only.

This commit makes the following small additions to make generating a `PrivateKey` easy:
- Implemented `rand_core::RngCore` for `secret_toolkit_crypto::rand::Prng` (forwarding methods to the inner `ChaChaRng`).
- Added a `pub fn generate<R: RngCore>(rng: &mut R) -> PrivateKey` function to `secret_toolkit_crypto::secp256k1::PrivateKey`.

You can see just how easy this makes it in the unit test added to `packages/crypto/src/secp256k1.rs`.

Now there is a secure source of on-chain entropy in the form of Scrt-RNG, a common use case may be to generate a private key within a secret contract. It might be handy if secret-toolkit supported this with an easy interface. On other hand it might not be desirable to make it so easy, as users may be tempted to generate keys from insecure sources of entropy. 