### PR TITLE
Update metadata structs to match SNIP-721 format

### DIFF
--- a/packages/snip721/src/metadata.rs
+++ b/packages/snip721/src/metadata.rs
@@ -82,3 +82,4 @@ pub struct Authentication {
     pub key: Option<String>,
     /// username used in basic authentication
     pub user: Option<String>,
+}

--- a/packages/snip721/src/metadata.rs
+++ b/packages/snip721/src/metadata.rs
@@ -5,12 +5,80 @@ use serde::{Deserialize, Serialize};
 //
 
 /// token metadata
-#[derive(Serialize, Deserialize, JsonSchema, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, JsonSchema, Clone, PartialEq, Debug, Default)]
 pub struct Metadata {
-    /// optional indentifier
-    pub name: Option<String>,
-    /// optional description
-    pub description: Option<String>,
-    /// optional uri to contain an image, additional data fields, etc...
-    pub image: Option<String>,
+    /// optional uri for off-chain metadata.  This should be prefixed with `http://`, `https://`, `ipfs://`, or
+    /// `ar://`.  Only use this if you are not using `extension`
+    pub token_uri: Option<String>,
+    /// optional on-chain metadata.  Only use this if you are not using `token_uri`
+    pub extension: Option<Extension>,
 }
+
+/// metadata extension
+/// You can add any metadata fields you need here.  These fields are based on
+/// https://docs.opensea.io/docs/metadata-standards and are the metadata fields that
+/// Stashh uses for robust NFT display.  Urls should be prefixed with `http://`, `https://`, `ipfs://`, or
+/// `ar://`
+#[derive(Serialize, Deserialize, JsonSchema, Clone, PartialEq, Debug, Default)]
+pub struct Extension {
+    /// url to the image
+    pub image: Option<String>,
+    /// raw SVG image data (not recommended). Only use this if you're not including the image parameter
+    pub image_data: Option<String>,
+    /// url to allow users to view the item on your site
+    pub external_url: Option<String>,
+    /// item description
+    pub description: Option<String>,
+    /// name of the item
+    pub name: Option<String>,
+    /// item attributes
+    pub attributes: Option<Vec<Trait>>,
+    /// background color represented as a six-character hexadecimal without a pre-pended #
+    pub background_color: Option<String>,
+    /// url to a multimedia attachment
+    pub animation_url: Option<String>,
+    /// url to a YouTube video
+    pub youtube_url: Option<String>,
+    /// media files as specified on Stashh that allows for basic authenticatiion and decryption keys.
+    /// Most of the above is used for bridging public eth NFT metadata easily, whereas `media` will be used
+    /// when minting NFTs on Stashh
+    pub media: Option<Vec<MediaFile>>,
+    /// a select list of trait_types that are in the private metadata.  This will only ever be used
+    /// in public metadata
+    pub protected_attributes: Option<Vec<String>>,
+}
+
+/// attribute trait
+#[derive(Serialize, Deserialize, JsonSchema, Clone, PartialEq, Debug, Default)]
+pub struct Trait {
+    /// indicates how a trait should be displayed
+    pub display_type: Option<String>,
+    /// name of the trait
+    pub trait_type: Option<String>,
+    /// trait value
+    pub value: String,
+    /// optional max value for numerical traits
+    pub max_value: Option<String>,
+}
+
+/// media file
+#[derive(Serialize, Deserialize, JsonSchema, Clone, PartialEq, Debug, Default)]
+pub struct MediaFile {
+    /// file type
+    /// Stashh currently uses: "image", "video", "audio", "text", "font", "application"
+    pub file_type: Option<String>,
+    /// file extension
+    pub extension: Option<String>,
+    /// authentication information
+    pub authentication: Option<Authentication>,
+    /// url to the file.  Urls should be prefixed with `http://`, `https://`, `ipfs://`, or `ar://`
+    pub url: String,
+}
+
+/// media file authentication
+#[derive(Serialize, Deserialize, JsonSchema, Clone, PartialEq, Debug, Default)]
+pub struct Authentication {
+    /// either a decryption key for encrypted files or a password for basic authentication
+    pub key: Option<String>,
+    /// username used in basic authentication
+    pub user: Option<String>,


### PR DESCRIPTION
Updates Metadata struct, and adds Extension, Trait, MediaFile, and Authentication structs to bring up to date with SNIP-721 reference implementation.