### PR TITLE
Added the `viewing_key` package

### DIFF
--- a/Releses.md
+++ b/Releses.md
@@ -6,6 +6,7 @@
 * BUGFIX: `secret-toolkit::snip721::Metadata` was severely out of date with the SNIP-721 specification, and not useful.
   It is now compatible with deployed SNIP-721 contracts.
 * Added `types` module under the `util` package, to standardize often used types.
+* Added `secret-toolkit::viewing_key`, which can be imported by enabling the `viewing-key` feature.
 
 ## v0.2.0
 This release includes a ton of new features, and a few breaking changes in various interfaces.

--- a/packages/toolkit/Cargo.toml
+++ b/packages/toolkit/Cargo.toml
@@ -24,6 +24,7 @@ snip20 = ["secret-toolkit-snip20", "utils"]
 snip721 = ["secret-toolkit-snip721", "utils"]
 storage = ["secret-toolkit-storage", "serialization"]
 utils = ["secret-toolkit-utils"]
+viewing-key = ["secret-toolkit-viewing-key"]
 
 [dependencies]
 secret-toolkit-crypto = { version = "0.2", path = "../crypto", optional = true }
@@ -34,3 +35,4 @@ secret-toolkit-snip20 = { version = "0.2", path = "../snip20", optional = true }
 secret-toolkit-snip721 = { version = "0.2", path = "../snip721", optional = true }
 secret-toolkit-storage = { version = "0.2", path = "../storage", optional = true }
 secret-toolkit-utils = { version = "0.2", path = "../utils", optional = true }
+secret-toolkit-viewing-key = { version = "0.2", path = "../viewing_key", optional = true }

--- a/packages/toolkit/src/lib.rs
+++ b/packages/toolkit/src/lib.rs
@@ -14,3 +14,5 @@ pub use secret_toolkit_snip721 as snip721;
 pub use secret_toolkit_storage as storage;
 #[cfg(feature = "utils")]
 pub use secret_toolkit_utils as utils;
+#[cfg(feature = "viewing-key")]
+pub use secret_toolkit_viewing_key as viewing_key;

--- a/packages/viewing_key/Cargo.toml
+++ b/packages/viewing_key/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "secret-toolkit-viewing-key"
+version = "0.2.0"
+edition = "2018"
+authors = ["SCRT Labs <info@scrtlabs.com>"]
+license-file = "../../LICENSE"
+repository = "https://github.com/scrtlabs/secret-toolkit"
+readme = "Readme.md"
+description = "Boilerplate for using viewing keys in Secret Contracts"
+categories = ["cryptography::cryptocurrencies", "wasm"]
+keywords = ["secret-network", "secret-contracts", "secret-toolkit"]
+
+[dependencies]
+serde = "1.0"
+schemars = "0.7"
+remain = "0.2.2"
+base64 = "0.11.0" # Same as used by cosmwas-std
+subtle = { version = "2.2.3", default-features = false }
+ripemd160 = "0.9.1"
+secp256k1 = "0.20.3"
+cosmwasm-std = { package = "secret-cosmwasm-std", version = "0.10" }
+cosmwasm-storage = { package = "secret-cosmwasm-storage", version = "0.10" }
+secret-toolkit-crypto = { version = "0.2", path = "../crypto" }
+secret-toolkit-utils = { version = "0.2", path = "../utils" }

--- a/packages/viewing_key/Readme.md
+++ b/packages/viewing_key/Readme.md
@@ -1,0 +1,5 @@
+# Secret Contract Development Toolkit - Permits
+
+⚠️ This package is a sub-package of the `secret-toolkit` package. Please see its crate page for more context.
+
+Utils for implementing permits, used by SNIP20 & SNIP721.

--- a/packages/viewing_key/src/lib.rs
+++ b/packages/viewing_key/src/lib.rs
@@ -9,6 +9,7 @@ use secret_toolkit_crypto::{sha_256, Prng, SHA256_HASH_SIZE};
 
 pub const VIEWING_KEY_SIZE: usize = SHA256_HASH_SIZE;
 pub const VIEWING_KEY_PREFIX: &str = "api_key_";
+const SEED_KEY: &[u8] = b"::seed";
 
 /// This is the default implementation of the viewing key store, using the "viewing_keys"
 /// storage prefix.
@@ -27,20 +28,36 @@ impl ViewingKeyStore for ViewingKey {
 pub trait ViewingKeyStore {
     const STORAGE_KEY: &'static [u8];
 
+    /// Set the initial prng seed for the store
+    fn set_seed<S: Storage>(storage: &mut S, seed: &[u8]) {
+        let mut seed_key = Vec::new();
+        seed_key.extend_from_slice(Self::STORAGE_KEY);
+        seed_key.extend_from_slice(b"::seed");
+
+        storage.set(&seed_key, seed)
+    }
+
     /// Create a new viewing key, save it to storage, and return it.
     ///
-    /// The random seed and entropy should be managed externally
+    /// The random entropy should be provided from some external source, such as the user.
     fn create<S: Storage>(
         storage: &mut S,
         env: &Env,
         account: &HumanAddr,
-        seed: &[u8],
         entropy: &[u8],
     ) -> String {
-        let viewing_key = new_viewing_key(env, seed, entropy);
+        let mut seed_key = Vec::with_capacity(Self::STORAGE_KEY.len() + SEED_KEY.len());
+        seed_key.extend_from_slice(Self::STORAGE_KEY);
+        seed_key.extend_from_slice(SEED_KEY);
+        let seed = storage.get(&seed_key).unwrap_or_default();
+
+        let (viewing_key, next_seed) = new_viewing_key(env, &seed, entropy);
         let mut balance_store = PrefixedStorage::new(Self::STORAGE_KEY, storage);
         let hashed_key = sha_256(viewing_key.as_bytes());
         balance_store.set(account.as_str().as_bytes(), &hashed_key);
+
+        storage.set(&seed_key, &next_seed);
+
         viewing_key
     }
 
@@ -74,7 +91,7 @@ pub trait ViewingKeyStore {
     }
 }
 
-fn new_viewing_key(env: &Env, seed: &[u8], entropy: &[u8]) -> String {
+fn new_viewing_key(env: &Env, seed: &[u8], entropy: &[u8]) -> (String, [u8; 32]) {
     // 16 here represents the lengths in bytes of the block height and time.
     let entropy_len = 16 + env.message.sender.len() + entropy.len();
     let mut rng_entropy = Vec::with_capacity(entropy_len);
@@ -89,7 +106,8 @@ fn new_viewing_key(env: &Env, seed: &[u8], entropy: &[u8]) -> String {
 
     let key = sha_256(&rand_slice);
 
-    VIEWING_KEY_PREFIX.to_string() + &base64::encode(&key)
+    let viewing_key = VIEWING_KEY_PREFIX.to_string() + &base64::encode(&key);
+    (viewing_key, rand_slice)
 }
 
 fn ct_slice_compare(s1: &[u8], s2: &[u8]) -> bool {
@@ -113,11 +131,15 @@ mod tests {
         let result = ViewingKey::check(&deps.storage, &account, "fake key");
         assert_eq!(result, Err(StdError::unauthorized()));
 
-        let viewing_key =
-            ViewingKey::create(&mut deps.storage, &env, &account, b"seed", b"entropy");
+        ViewingKey::set_seed(&mut deps.storage, b"seed");
+        let viewing_key = ViewingKey::create(&mut deps.storage, &env, &account, b"entropy");
 
         let result = ViewingKey::check(&deps.storage, &account, &viewing_key);
         assert_eq!(result, Ok(()));
+
+        // Create a key with the same entropy. Check that it's different
+        let viewing_key_2 = ViewingKey::create(&mut deps.storage, &env, &account, b"entropy");
+        assert_ne!(viewing_key, viewing_key_2);
 
         // VK set to another key:
         let result = ViewingKey::check(&deps.storage, &account, "fake key");

--- a/packages/viewing_key/src/lib.rs
+++ b/packages/viewing_key/src/lib.rs
@@ -1,0 +1,137 @@
+extern crate core;
+
+use subtle::ConstantTimeEq;
+
+use cosmwasm_std::{Env, HumanAddr, ReadonlyStorage, StdError, StdResult, Storage};
+use cosmwasm_storage::{PrefixedStorage, ReadonlyPrefixedStorage};
+
+use secret_toolkit_crypto::{sha_256, Prng, SHA256_HASH_SIZE};
+
+pub const VIEWING_KEY_SIZE: usize = SHA256_HASH_SIZE;
+pub const VIEWING_KEY_PREFIX: &str = "api_key_";
+
+/// This is the default implementation of the viewing key store, using the "viewing_keys"
+/// storage prefix.
+///
+/// You can use another storage location by implementing `ViewingKeyStore` for your own type.
+pub struct ViewingKey;
+
+impl ViewingKeyStore for ViewingKey {
+    const STORAGE_KEY: &'static [u8] = b"viewing_keys";
+}
+
+/// A trait describing the interface of a Viewing Key store/vault.
+///
+/// It includes a default implementation that only requires specifying where in the storage
+/// the keys should be held.
+pub trait ViewingKeyStore {
+    const STORAGE_KEY: &'static [u8];
+
+    /// Create a new viewing key, save it to storage, and return it.
+    ///
+    /// The random seed and entropy should be managed externally
+    fn create<S: Storage>(
+        storage: &mut S,
+        env: &Env,
+        account: &HumanAddr,
+        seed: &[u8],
+        entropy: &[u8],
+    ) -> String {
+        let viewing_key = new_viewing_key(env, seed, entropy);
+        let mut balance_store = PrefixedStorage::new(Self::STORAGE_KEY, storage);
+        let hashed_key = sha_256(viewing_key.as_bytes());
+        balance_store.set(account.as_str().as_bytes(), &hashed_key);
+        viewing_key
+    }
+
+    /// Set a new viewing key based on a predetermined value.
+    fn set<S: Storage>(storage: &mut S, account: &HumanAddr, viewing_key: &str) {
+        let mut balance_store = PrefixedStorage::new(Self::STORAGE_KEY, storage);
+        balance_store.set(
+            account.as_str().as_bytes(),
+            &sha_256(viewing_key.as_bytes()),
+        );
+    }
+
+    /// Check if a viewing key matches an account.
+    fn check<S: ReadonlyStorage>(
+        storage: &S,
+        account: &HumanAddr,
+        viewing_key: &str,
+    ) -> StdResult<()> {
+        let balance_store = ReadonlyPrefixedStorage::new(Self::STORAGE_KEY, storage);
+        let expected_hash = balance_store.get(account.as_str().as_bytes());
+        let expected_hash = match &expected_hash {
+            Some(hash) => hash.as_slice(),
+            None => &[0u8; VIEWING_KEY_SIZE],
+        };
+        let key_hash = sha_256(viewing_key.as_bytes());
+        if ct_slice_compare(&key_hash, expected_hash) {
+            Ok(())
+        } else {
+            Err(StdError::unauthorized())
+        }
+    }
+}
+
+fn new_viewing_key(env: &Env, seed: &[u8], entropy: &[u8]) -> String {
+    // 16 here represents the lengths in bytes of the block height and time.
+    let entropy_len = 16 + env.message.sender.len() + entropy.len();
+    let mut rng_entropy = Vec::with_capacity(entropy_len);
+    rng_entropy.extend_from_slice(&env.block.height.to_be_bytes());
+    rng_entropy.extend_from_slice(&env.block.time.to_be_bytes());
+    rng_entropy.extend_from_slice(&env.message.sender.0.as_bytes());
+    rng_entropy.extend_from_slice(entropy);
+
+    let mut rng = Prng::new(seed, &rng_entropy);
+
+    let rand_slice = rng.rand_bytes();
+
+    let key = sha_256(&rand_slice);
+
+    VIEWING_KEY_PREFIX.to_string() + &base64::encode(&key)
+}
+
+fn ct_slice_compare(s1: &[u8], s2: &[u8]) -> bool {
+    bool::from(s1.ct_eq(s2))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use cosmwasm_std::testing::{mock_dependencies, mock_env};
+
+    #[test]
+    fn test_viewing_keys() {
+        let account = HumanAddr("user-1".to_string());
+
+        let mut deps = mock_dependencies(20, &[]);
+        let env = mock_env(account.as_str(), &[]);
+
+        // VK not set yet:
+        let result = ViewingKey::check(&deps.storage, &account, "fake key");
+        assert_eq!(result, Err(StdError::unauthorized()));
+
+        let viewing_key =
+            ViewingKey::create(&mut deps.storage, &env, &account, b"seed", b"entropy");
+
+        let result = ViewingKey::check(&deps.storage, &account, &viewing_key);
+        assert_eq!(result, Ok(()));
+
+        // VK set to another key:
+        let result = ViewingKey::check(&deps.storage, &account, "fake key");
+        assert_eq!(result, Err(StdError::unauthorized()));
+
+        let viewing_key = "custom key";
+
+        ViewingKey::set(&mut deps.storage, &account, viewing_key);
+
+        let result = ViewingKey::check(&deps.storage, &account, viewing_key);
+        assert_eq!(result, Ok(()));
+
+        // VK set to another key:
+        let result = ViewingKey::check(&deps.storage, &account, "fake key");
+        assert_eq!(result, Err(StdError::unauthorized()));
+    }
+}

--- a/packages/viewing_key/src/lib.rs
+++ b/packages/viewing_key/src/lib.rs
@@ -32,7 +32,7 @@ pub trait ViewingKeyStore {
     fn set_seed<S: Storage>(storage: &mut S, seed: &[u8]) {
         let mut seed_key = Vec::new();
         seed_key.extend_from_slice(Self::STORAGE_KEY);
-        seed_key.extend_from_slice(b"::seed");
+        seed_key.extend_from_slice(SEED_KEY);
 
         storage.set(&seed_key, seed)
     }


### PR DESCRIPTION
This PR implements a viewing key store that requires minimum effort to set up. In its most basic form, you can hit the ground running with:
```rust
use secret_toolkit::viewing_key::{ViewingKey, ViewingKeyStore};

// In your init function
ViewingKey::set_seed(&mut deps.storage, &seed);

ViewingKey::set(&mut deps.storage, &address, &key);
// or
let key = ViewingKey::create(&deps.storage, &env, &address, &entropy);

// Will fail if the key does not match
ViewingKey::check(&deps.storage, &address, &key)?;
```

This type stores all viewing keys under the the top level storage key "viewing_keys", and its methods are available by importing the `ViewingKeyStore` trait.

The top-level storage key can be changed by implementing the trait on your own type:

```rust
use secret_toolkit::viewing_key::ViewingKeyStore;

pub struct CustomViewingKey;

impl ViewingKeyStore for CustomViewingKey {
    const STORAGE_KEY: &'static [u8] = b"custom_viewing_keys";
}
```

:warning: The PRNG seed for the `create` method is stored under `Self::STORAGE_KEY + "::seed"`