### PR TITLE
small improvements to permit module

### DIFF
--- a/Releses.md
+++ b/Releses.md
@@ -7,6 +7,10 @@
   It is now compatible with deployed SNIP-721 contracts.
 * Added `types` module under the `util` package, to standardize often used types.
 * Added `secret-toolkit::viewing_key`, which can be imported by enabling the `viewing-key` feature.
+* Added `secret-toolkit::permit::PubKey::canonical_address()`
+
+### Breaking
+* `secret-toolkit::permit::validate()` now takes a reference to the current token address instead of taking it by value.
 
 ## v0.2.0
 This release includes a ton of new features, and a few breaking changes in various interfaces.

--- a/packages/permit/src/funcs.rs
+++ b/packages/permit/src/funcs.rs
@@ -10,9 +10,9 @@ pub fn validate<S: Storage, A: Api, Q: Querier>(
     deps: &Extern<S, A, Q>,
     storage_prefix: &str,
     permit: &Permit,
-    current_token_address: HumanAddr,
+    current_token_address: &HumanAddr,
 ) -> StdResult<HumanAddr> {
-    if !permit.check_token(&current_token_address) {
+    if !permit.check_token(current_token_address) {
         return Err(StdError::generic_err(format!(
             "Permit doesn't apply to token {:?}, allowed tokens: {:?}",
             current_token_address.as_str(),

--- a/packages/permit/src/structs.rs
+++ b/packages/permit/src/structs.rs
@@ -3,7 +3,8 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use cosmwasm_std::{Binary, HumanAddr, Uint128};
+use crate::pubkey_to_account;
+use cosmwasm_std::{Binary, CanonicalAddr, HumanAddr, Uint128};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
@@ -45,6 +46,12 @@ pub struct PubKey {
     pub r#type: String,
     /// Secp256k1 PubKey
     pub value: Binary,
+}
+
+impl PubKey {
+    pub fn canonical_address(&self) -> CanonicalAddr {
+        pubkey_to_account(&self.value)
+    }
 }
 
 // Note: The order of fields in this struct is important for the permit signature verification!


### PR DESCRIPTION
- Added `secret-toolkit::permit::PubKey::canonical_address()`
- BREAKING: `secret-toolkit::permit::validate()` now takes a reference to the current token address instead of taking it by value.