### PR TITLE
updated toolkit for shockwave alpha

### DIFF
--- a/packages/crypto/Cargo.toml
+++ b/packages/crypto/Cargo.toml
@@ -18,7 +18,7 @@ sha2 = { version = "0.9.1", default-features = false }
 libsecp256k1 = { version = "0.3.5", default-features = false, features = [
     "hmac"
 ] }
-cosmwasm-std = { package = "secret-cosmwasm-std", version = "0.10" }
+cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", branch = "backport-cw-crypto-apis-to-v0.10", package = "secret-cosmwasm-std" }
 
 [dev-dependencies]
 secp256k1-test = { package = "secp256k1", version = "0.17", features = [

--- a/packages/crypto/Cargo.toml
+++ b/packages/crypto/Cargo.toml
@@ -18,7 +18,7 @@ sha2 = { version = "0.9.1", default-features = false }
 libsecp256k1 = { version = "0.3.5", default-features = false, features = [
     "hmac"
 ] }
-cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", branch = "backport-cw-crypto-apis-to-v0.10", package = "secret-cosmwasm-std" }
+cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", package = "secret-cosmwasm-std" }
 
 [dev-dependencies]
 secp256k1-test = { package = "secp256k1", version = "0.17", features = [

--- a/packages/crypto/Cargo.toml
+++ b/packages/crypto/Cargo.toml
@@ -18,7 +18,7 @@ sha2 = { version = "0.9.1", default-features = false }
 libsecp256k1 = { version = "0.3.5", default-features = false, features = [
     "hmac"
 ] }
-cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", package = "secret-cosmwasm-std" }
+cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", version = "0.10.0", package = "secret-cosmwasm-std" }
 
 [dev-dependencies]
 secp256k1-test = { package = "secp256k1", version = "0.17", features = [

--- a/packages/incubator/Cargo.toml
+++ b/packages/incubator/Cargo.toml
@@ -13,6 +13,6 @@ keywords = ["secret-network", "secret-contracts", "secret-toolkit"]
 [dependencies]
 serde = "1.0"
 siphasher = "0.3.0"
-cosmwasm-std = { package = "secret-cosmwasm-std", version = "0.10" }
-cosmwasm-storage = { package = "secret-cosmwasm-storage", version = "0.10" }
+cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", branch = "backport-cw-crypto-apis-to-v0.10", package = "secret-cosmwasm-std" }
+cosmwasm-storage = { git = "https://github.com/scrtlabs/SecretNetwork", branch = "backport-cw-crypto-apis-to-v0.10", package = "secret-cosmwasm-storage" }
 secret-toolkit-serialization = { version = "0.2", path = "../serialization" }

--- a/packages/incubator/Cargo.toml
+++ b/packages/incubator/Cargo.toml
@@ -13,6 +13,6 @@ keywords = ["secret-network", "secret-contracts", "secret-toolkit"]
 [dependencies]
 serde = "1.0"
 siphasher = "0.3.0"
-cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", branch = "backport-cw-crypto-apis-to-v0.10", package = "secret-cosmwasm-std" }
-cosmwasm-storage = { git = "https://github.com/scrtlabs/SecretNetwork", branch = "backport-cw-crypto-apis-to-v0.10", package = "secret-cosmwasm-storage" }
+cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", package = "secret-cosmwasm-std" }
+cosmwasm-storage = { git = "https://github.com/scrtlabs/SecretNetwork", package = "secret-cosmwasm-storage" }
 secret-toolkit-serialization = { version = "0.2", path = "../serialization" }

--- a/packages/incubator/Cargo.toml
+++ b/packages/incubator/Cargo.toml
@@ -13,6 +13,6 @@ keywords = ["secret-network", "secret-contracts", "secret-toolkit"]
 [dependencies]
 serde = "1.0"
 siphasher = "0.3.0"
-cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", package = "secret-cosmwasm-std" }
-cosmwasm-storage = { git = "https://github.com/scrtlabs/SecretNetwork", package = "secret-cosmwasm-storage" }
+cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", version = "0.10.0", package = "secret-cosmwasm-std" }
+cosmwasm-storage = { git = "https://github.com/scrtlabs/SecretNetwork", version = "0.10.0", package = "secret-cosmwasm-storage" }
 secret-toolkit-serialization = { version = "0.2", path = "../serialization" }

--- a/packages/permit/Cargo.toml
+++ b/packages/permit/Cargo.toml
@@ -16,6 +16,6 @@ schemars = "0.7"
 remain = "0.2.2"
 ripemd160 = "0.9.1"
 secp256k1 = "0.20.3"
-cosmwasm-std = { package = "secret-cosmwasm-std", version = "0.10" }
+cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", branch = "backport-cw-crypto-apis-to-v0.10", package = "secret-cosmwasm-std" }
 secret-toolkit-crypto = { version = "0.2", path = "../crypto" }
 secret-toolkit-utils = { version = "0.2", path = "../utils" }

--- a/packages/permit/Cargo.toml
+++ b/packages/permit/Cargo.toml
@@ -15,6 +15,6 @@ serde = "1.0"
 schemars = "0.7"
 remain = "0.2.2"
 ripemd160 = "0.9.1"
-cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", branch = "backport-cw-crypto-apis-to-v0.10", package = "secret-cosmwasm-std" }
+cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", package = "secret-cosmwasm-std" }
 secret-toolkit-crypto = { version = "0.2", path = "../crypto" }
 secret-toolkit-utils = { version = "0.2", path = "../utils" }

--- a/packages/permit/Cargo.toml
+++ b/packages/permit/Cargo.toml
@@ -15,6 +15,6 @@ serde = "1.0"
 schemars = "0.7"
 remain = "0.2.2"
 ripemd160 = "0.9.1"
-cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", package = "secret-cosmwasm-std" }
+cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", version = "0.10.0", package = "secret-cosmwasm-std" }
 secret-toolkit-crypto = { version = "0.2", path = "../crypto" }
 secret-toolkit-utils = { version = "0.2", path = "../utils" }

--- a/packages/permit/Cargo.toml
+++ b/packages/permit/Cargo.toml
@@ -15,7 +15,6 @@ serde = "1.0"
 schemars = "0.7"
 remain = "0.2.2"
 ripemd160 = "0.9.1"
-secp256k1 = "0.20.3"
 cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", branch = "backport-cw-crypto-apis-to-v0.10", package = "secret-cosmwasm-std" }
 secret-toolkit-crypto = { version = "0.2", path = "../crypto" }
 secret-toolkit-utils = { version = "0.2", path = "../utils" }

--- a/packages/permit/src/funcs.rs
+++ b/packages/permit/src/funcs.rs
@@ -2,7 +2,6 @@ use cosmwasm_std::{
     to_binary, Api, Binary, CanonicalAddr, Extern, HumanAddr, Querier, StdError, StdResult, Storage,
 };
 use ripemd160::{Digest, Ripemd160};
-use secp256k1::Secp256k1;
 
 use crate::{Permit, RevokedPermits, SignedPermit};
 
@@ -41,32 +40,20 @@ pub fn validate<S: Storage, A: Api, Q: Querier>(
         )));
     }
 
-    // Validate signature, reference: https://github.com/enigmampc/SecretNetwork/blob/f591ed0cb3af28608df3bf19d6cfb733cca48100/cosmwasm/packages/wasmi-runtime/src/crypto/secp256k1.rs#L49-L82
+    // Verify signature
     let signed_bytes = to_binary(&SignedPermit::from_params(&permit.params))?;
     let signed_bytes_hash = secret_toolkit_crypto::sha_256(signed_bytes.as_slice());
-    let secp256k1_msg = secp256k1::Message::from_slice(&signed_bytes_hash).map_err(|err| {
-        StdError::generic_err(format!(
-            "Failed to create a secp256k1 message from signed_bytes: {:?}",
-            err
-        ))
+    let validated = deps.api.secp256k1_verify(
+        signed_bytes_hash.as_slice(),
+        permit.signature.signature.0.as_slice(),
+        pubkey.as_slice(),
+    ).map_err(|err| {
+        StdError::generic_err(format!("{:?}", err))
     })?;
 
-    let secp256k1_verifier = Secp256k1::verification_only();
-
-    let secp256k1_signature = secp256k1::Signature::from_compact(&permit.signature.signature.0)
-        .map_err(|err| StdError::generic_err(format!("Malformed signature: {:?}", err)))?;
-    let secp256k1_pubkey = secp256k1::PublicKey::from_slice(pubkey.0.as_slice())
-        .map_err(|err| StdError::generic_err(format!("Malformed pubkey: {:?}", err)))?;
-
-    secp256k1_verifier
-        .verify(&secp256k1_msg, &secp256k1_signature, &secp256k1_pubkey)
-        .map_err(|err| {
-            StdError::generic_err(format!(
-                "Failed to verify signatures for the given permit: {:?}",
-                err
-            ))
-        })?;
-
+    if !validated {
+        return Err(StdError::generic_err(format!("Permit {:?} was not validated", permit_name)));
+    }
     Ok(account)
 }
 

--- a/packages/permit/src/funcs.rs
+++ b/packages/permit/src/funcs.rs
@@ -43,7 +43,7 @@ pub fn validate<S: Storage, A: Api, Q: Querier>(
     // Verify signature
     let signed_bytes = to_binary(&SignedPermit::from_params(&permit.params))?;
     let signed_bytes_hash = secret_toolkit_crypto::sha_256(signed_bytes.as_slice());
-    let validated = deps.api.secp256k1_verify(
+    let verified = deps.api.secp256k1_verify(
         signed_bytes_hash.as_slice(),
         permit.signature.signature.0.as_slice(),
         pubkey.as_slice(),
@@ -51,8 +51,8 @@ pub fn validate<S: Storage, A: Api, Q: Querier>(
         StdError::generic_err(format!("{:?}", err))
     })?;
 
-    if !validated {
-        return Err(StdError::generic_err(format!("Permit {:?} was not validated", permit_name)));
+    if !verified {
+        return Err(StdError::generic_err(format!("Permit {:?} signature was not verified", permit_name)));
     }
     Ok(account)
 }

--- a/packages/permit/src/state.rs
+++ b/packages/permit/src/state.rs
@@ -4,14 +4,14 @@ pub struct RevokedPermits;
 
 impl RevokedPermits {
     pub fn is_permit_revoked(
-        storgae: &dyn Storage,
+        storage: &dyn Storage,
         storage_prefix: &str,
         account: &HumanAddr,
         permit_name: &str,
     ) -> bool {
         let storage_key = storage_prefix.to_string() + &account.to_string() + permit_name;
 
-        storgae.get(storage_key.as_bytes()).is_some()
+        storage.get(storage_key.as_bytes()).is_some()
     }
 
     pub fn revoke_permit(

--- a/packages/serialization/Cargo.toml
+++ b/packages/serialization/Cargo.toml
@@ -19,7 +19,7 @@ base64 = ["schemars"]
 serde = "1.0"
 bincode2 = { version = "2.0", optional = true }
 schemars = { version = "0.7", optional = true }
-cosmwasm-std = { package = "secret-cosmwasm-std", version = "0.10" }
+cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", branch = "backport-cw-crypto-apis-to-v0.10", package = "secret-cosmwasm-std" }
 
 [dev-dependencies]
 serde_json = "1"

--- a/packages/serialization/Cargo.toml
+++ b/packages/serialization/Cargo.toml
@@ -19,7 +19,7 @@ base64 = ["schemars"]
 serde = "1.0"
 bincode2 = { version = "2.0", optional = true }
 schemars = { version = "0.7", optional = true }
-cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", branch = "backport-cw-crypto-apis-to-v0.10", package = "secret-cosmwasm-std" }
+cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", package = "secret-cosmwasm-std" }
 
 [dev-dependencies]
 serde_json = "1"

--- a/packages/serialization/Cargo.toml
+++ b/packages/serialization/Cargo.toml
@@ -19,7 +19,7 @@ base64 = ["schemars"]
 serde = "1.0"
 bincode2 = { version = "2.0", optional = true }
 schemars = { version = "0.7", optional = true }
-cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", package = "secret-cosmwasm-std" }
+cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", version = "0.10.0", package = "secret-cosmwasm-std" }
 
 [dev-dependencies]
 serde_json = "1"

--- a/packages/snip20/Cargo.toml
+++ b/packages/snip20/Cargo.toml
@@ -13,5 +13,5 @@ keywords = ["secret-network", "secret-contracts", "secret-toolkit"]
 [dependencies]
 serde = "1.0"
 schemars = "0.7"
-cosmwasm-std = { package = "secret-cosmwasm-std", version = "0.10" }
+cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", branch = "backport-cw-crypto-apis-to-v0.10", package = "secret-cosmwasm-std" }
 secret-toolkit-utils = { version = "0.2", path = "../utils" }

--- a/packages/snip20/Cargo.toml
+++ b/packages/snip20/Cargo.toml
@@ -13,5 +13,5 @@ keywords = ["secret-network", "secret-contracts", "secret-toolkit"]
 [dependencies]
 serde = "1.0"
 schemars = "0.7"
-cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", branch = "backport-cw-crypto-apis-to-v0.10", package = "secret-cosmwasm-std" }
+cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", package = "secret-cosmwasm-std" }
 secret-toolkit-utils = { version = "0.2", path = "../utils" }

--- a/packages/snip20/Cargo.toml
+++ b/packages/snip20/Cargo.toml
@@ -13,5 +13,5 @@ keywords = ["secret-network", "secret-contracts", "secret-toolkit"]
 [dependencies]
 serde = "1.0"
 schemars = "0.7"
-cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", package = "secret-cosmwasm-std" }
+cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", version = "0.10.0", package = "secret-cosmwasm-std" }
 secret-toolkit-utils = { version = "0.2", path = "../utils" }

--- a/packages/snip721/Cargo.toml
+++ b/packages/snip721/Cargo.toml
@@ -13,5 +13,5 @@ keywords = ["secret-network", "secret-contracts", "secret-toolkit"]
 [dependencies]
 serde = "1.0"
 schemars = "0.7"
-cosmwasm-std = { package = "secret-cosmwasm-std", version = "0.10" }
+cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", branch = "backport-cw-crypto-apis-to-v0.10", package = "secret-cosmwasm-std" }
 secret-toolkit-utils = { version = "0.2", path = "../utils" }

--- a/packages/snip721/Cargo.toml
+++ b/packages/snip721/Cargo.toml
@@ -13,5 +13,5 @@ keywords = ["secret-network", "secret-contracts", "secret-toolkit"]
 [dependencies]
 serde = "1.0"
 schemars = "0.7"
-cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", branch = "backport-cw-crypto-apis-to-v0.10", package = "secret-cosmwasm-std" }
+cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", package = "secret-cosmwasm-std" }
 secret-toolkit-utils = { version = "0.2", path = "../utils" }

--- a/packages/snip721/Cargo.toml
+++ b/packages/snip721/Cargo.toml
@@ -13,5 +13,5 @@ keywords = ["secret-network", "secret-contracts", "secret-toolkit"]
 [dependencies]
 serde = "1.0"
 schemars = "0.7"
-cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", package = "secret-cosmwasm-std" }
+cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", version = "0.10.0", package = "secret-cosmwasm-std" }
 secret-toolkit-utils = { version = "0.2", path = "../utils" }

--- a/packages/storage/Cargo.toml
+++ b/packages/storage/Cargo.toml
@@ -12,6 +12,6 @@ keywords = ["secret-network", "secret-contracts", "secret-toolkit"]
 
 [dependencies]
 serde = "1.0"
-cosmwasm-std = { package = "secret-cosmwasm-std", version = "0.10" }
-cosmwasm-storage = { package = "secret-cosmwasm-storage", version = "0.10" }
+cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", branch = "backport-cw-crypto-apis-to-v0.10", package = "secret-cosmwasm-std" }
+cosmwasm-storage = { git = "https://github.com/scrtlabs/SecretNetwork", branch = "backport-cw-crypto-apis-to-v0.10", package = "secret-cosmwasm-storage" }
 secret-toolkit-serialization = { version = "0.2", path = "../serialization" }

--- a/packages/storage/Cargo.toml
+++ b/packages/storage/Cargo.toml
@@ -12,6 +12,6 @@ keywords = ["secret-network", "secret-contracts", "secret-toolkit"]
 
 [dependencies]
 serde = "1.0"
-cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", package = "secret-cosmwasm-std" }
-cosmwasm-storage = { git = "https://github.com/scrtlabs/SecretNetwork", package = "secret-cosmwasm-storage" }
+cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", version = "0.10.0", package = "secret-cosmwasm-std" }
+cosmwasm-storage = { git = "https://github.com/scrtlabs/SecretNetwork", version = "0.10.0", package = "secret-cosmwasm-storage" }
 secret-toolkit-serialization = { version = "0.2", path = "../serialization" }

--- a/packages/storage/Cargo.toml
+++ b/packages/storage/Cargo.toml
@@ -12,6 +12,6 @@ keywords = ["secret-network", "secret-contracts", "secret-toolkit"]
 
 [dependencies]
 serde = "1.0"
-cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", branch = "backport-cw-crypto-apis-to-v0.10", package = "secret-cosmwasm-std" }
-cosmwasm-storage = { git = "https://github.com/scrtlabs/SecretNetwork", branch = "backport-cw-crypto-apis-to-v0.10", package = "secret-cosmwasm-storage" }
+cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", package = "secret-cosmwasm-std" }
+cosmwasm-storage = { git = "https://github.com/scrtlabs/SecretNetwork", package = "secret-cosmwasm-storage" }
 secret-toolkit-serialization = { version = "0.2", path = "../serialization" }

--- a/packages/utils/Cargo.toml
+++ b/packages/utils/Cargo.toml
@@ -13,5 +13,5 @@ keywords = ["secret-network", "secret-contracts", "secret-toolkit"]
 [dependencies]
 serde = "1.0"
 schemars = "0.7"
-cosmwasm-std = { package = "secret-cosmwasm-std", version = "0.10" }
-cosmwasm-storage = { package = "secret-cosmwasm-storage", version = "0.10"}
+cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", branch = "backport-cw-crypto-apis-to-v0.10", package = "secret-cosmwasm-std" }
+cosmwasm-storage = { git = "https://github.com/scrtlabs/SecretNetwork", branch = "backport-cw-crypto-apis-to-v0.10", package = "secret-cosmwasm-storage" }

--- a/packages/utils/Cargo.toml
+++ b/packages/utils/Cargo.toml
@@ -13,5 +13,5 @@ keywords = ["secret-network", "secret-contracts", "secret-toolkit"]
 [dependencies]
 serde = "1.0"
 schemars = "0.7"
-cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", branch = "backport-cw-crypto-apis-to-v0.10", package = "secret-cosmwasm-std" }
-cosmwasm-storage = { git = "https://github.com/scrtlabs/SecretNetwork", branch = "backport-cw-crypto-apis-to-v0.10", package = "secret-cosmwasm-storage" }
+cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", version = "0.10.0", package = "secret-cosmwasm-std" }
+cosmwasm-storage = { git = "https://github.com/scrtlabs/SecretNetwork", version = "0.10.0", package = "secret-cosmwasm-storage" }

--- a/packages/viewing_key/Cargo.toml
+++ b/packages/viewing_key/Cargo.toml
@@ -18,7 +18,7 @@ base64 = "0.11.0" # Same as used by cosmwas-std
 subtle = { version = "2.2.3", default-features = false }
 ripemd160 = "0.9.1"
 secp256k1 = "0.20.3"
-cosmwasm-std = { package = "secret-cosmwasm-std", version = "0.10" }
-cosmwasm-storage = { package = "secret-cosmwasm-storage", version = "0.10" }
+cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", branch = "backport-cw-crypto-apis-to-v0.10", package = "secret-cosmwasm-std" }
+cosmwasm-storage = { git = "https://github.com/scrtlabs/SecretNetwork", branch = "backport-cw-crypto-apis-to-v0.10", package = "secret-cosmwasm-storage" }
 secret-toolkit-crypto = { version = "0.2", path = "../crypto" }
 secret-toolkit-utils = { version = "0.2", path = "../utils" }

--- a/packages/viewing_key/Cargo.toml
+++ b/packages/viewing_key/Cargo.toml
@@ -18,7 +18,7 @@ base64 = "0.11.0" # Same as used by cosmwas-std
 subtle = { version = "2.2.3", default-features = false }
 ripemd160 = "0.9.1"
 secp256k1 = "0.20.3"
-cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", branch = "backport-cw-crypto-apis-to-v0.10", package = "secret-cosmwasm-std" }
-cosmwasm-storage = { git = "https://github.com/scrtlabs/SecretNetwork", branch = "backport-cw-crypto-apis-to-v0.10", package = "secret-cosmwasm-storage" }
+cosmwasm-std = { git = "https://github.com/scrtlabs/SecretNetwork", version = "0.10.0", package = "secret-cosmwasm-std" }
+cosmwasm-storage = { git = "https://github.com/scrtlabs/SecretNetwork", version = "0.10.0", package = "secret-cosmwasm-storage" }
 secret-toolkit-crypto = { version = "0.2", path = "../crypto" }
 secret-toolkit-utils = { version = "0.2", path = "../utils" }


### PR DESCRIPTION
For a project I'm working on I updated secret-toolkit for shockwave alpha:

1. updated the Cargo.toml files in the secret-toolkit packages to use the new versions of cosmwasm-std and cosmwasm-storage, and 
2. updated the `validate` function in the permit package to use the new api function. 

I thought this might be helpful to merge before the upgrade. Though you might not want to merge yet if you are planning to put cosmwasm-std and cosmwasm-storage on crates.io, or you were planning some generalization of the permit that includes ed25519.