### PR TITLE
Prefixes added to AppendStore, and naming conventions for Cashmaps are modified

### DIFF
--- a/packages/incubator/Readme.md
+++ b/packages/incubator/Readme.md
@@ -21,7 +21,7 @@ You can open/initialize the cashmap directly using
 
 ```rust
 let mut storage = MockStorage::new();
-let mut cmap = CashMap::init(b"cashmap-name", &mut storage);
+let mut cmap = CashmapMut::init(b"cashmap-name", &mut storage);
 ```
 
 #### Access pattern

--- a/packages/incubator/src/cashmap.rs
+++ b/packages/incubator/src/cashmap.rs
@@ -141,8 +141,7 @@ where
             }
 
             // find the index of our item
-            // todo: replace this since we know the absolute position from the internalitem
-            let pos_in_indexes = indexes.iter().position(|index| index == &hash).unwrap();
+            let pos_in_indexes = (unwrapped_item.meta_data.position % PAGE_SIZE) as usize;
 
             // replace the last item with our new item
             let max_page = _page_from_position(len);
@@ -795,7 +794,7 @@ mod tests {
     fn test_hashmap_paging() -> StdResult<()> {
         let mut storage = MockStorage::new();
 
-        let page_size = 50;
+        let page_size = 5;
         let total_items = 50;
         let mut cashmap = CashMap::attach(&mut storage);
 
@@ -822,7 +821,7 @@ mod tests {
         let mut prefixed = PrefixedStorage::new(b"test", &mut storage);
         let mut cashmap = CashMap::init(b"yo", &mut prefixed);
 
-        let page_size = 50;
+        let page_size = 10;
         let total_items = 50;
         //let mut cashmap = CashMap::attach(&mut storage);
 

--- a/packages/incubator/src/lib.rs
+++ b/packages/incubator/src/lib.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "cashmap")]
 pub mod cashmap;
 #[cfg(feature = "cashmap")]
-pub use cashmap::{CashMap as CashmapMut, ReadOnlyCashMap as Cashmap};
+pub use cashmap::{CashmapMut, Cashmap};
 
 #[cfg(feature = "generational-store")]
 pub mod generational_store;

--- a/packages/incubator/src/lib.rs
+++ b/packages/incubator/src/lib.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "cashmap")]
 pub mod cashmap;
 #[cfg(feature = "cashmap")]
-pub use cashmap::{CashMap, ReadOnlyCashMap};
+pub use cashmap::{CashMap as CashmapMut, ReadOnlyCashMap as Cashmap};
 
 #[cfg(feature = "generational-store")]
 pub mod generational_store;

--- a/packages/storage/src/append_store.rs
+++ b/packages/storage/src/append_store.rs
@@ -288,6 +288,21 @@ where
     T: Serialize + DeserializeOwned,
     S: ReadonlyStorage,
 {
+    /// Try to use the provided storage as a prefixed AppendStore.
+    /// 
+    /// Returns None if the provided storage doesn't seem like an AppendStore.
+    /// Returns Err if the contents of the storage can not be parsed.
+    pub fn prefixed(namespace: &[u8], storage: &'a S) -> Option<StdResult<Self>> {
+        AppendStore::attach_with_serialization(storage, Some(namespace.to_vec()), Bincode2)
+    }
+    /// Try to use the provided storage as a multilevel prefixed AppendStore.
+    /// 
+    /// Returns None if the provided storage doesn't seem like an AppendStore.
+    /// Returns Err if the contents of the storage can not be parsed.
+    pub fn multilevel(namespaces: &[&[u8]], storage: &'a S) -> Option<StdResult<Self>> {
+        let namespace = to_length_prefixed_nested(namespaces);
+        AppendStore::attach_with_serialization(storage, Some(namespace), Bincode2)
+    }
     /// Try to use the provided storage as an AppendStore.
     ///
     /// Returns None if the provided storage doesn't seem like an AppendStore.


### PR DESCRIPTION
### Updates to AppendStore ###
Previously, the only way to initialize an AppendStore was to attach it to an already existing storage object. With this update, AppendStore can be initialized with a prefix or a multilevel prefix using:

```rust
let prefix: &[u8] = b"test_prefix";
let mut append_store: AppendStoreMut<i32, _> = AppendStoreMut::prefixed(prefix, &mut storage)?;
```
and

```rust
let mut storage = MockStorage::new();
let prefixes: &[&[u8]] = &[b"test_prefix", b"random_prefix"];
let mut append_store: AppendStoreMut<i32, _> = AppendStoreMut::multilevel(prefixes, &mut storage)?;
```
moreover, a pagination wrapper is added to AppendStore much like Cashmaps, used in the following manner:

```rust
let values: Vec<i32> = append_store.paging(start_page, page_size)?;
```

And finally, 5 new tests were added to test all these added features.

### Updates to Cashmaps ###
Cashmaney had left a to do message for a one line minor performance improvement, I completed this task.

I also changed the naming conventions of Cashmaps to make them more consistent with the rest of `secret-toolkit`. The new naming conventions are `CashMap -> CashmapMut` and `ReadOnlyCashMap -> Cashmap`. I want to note that this name change was done inside incubator's `lib.rs` when importing cashmaps with the following lines:

```rust
pub use cashmap::{CashMap as CashmapMut, ReadOnlyCashMap as Cashmap};
```

So anyone using `secret-toolkit-incubator` must import them as `Cashmap` and `CashmapMut` now. However, the internal code in `cashmap.rs` still uses the old naming conversions (I can also change this upon request but I didn't want to waste needless time.)

I also made minor modification to Cashmap pagination tests.