### PR TITLE
Minor updates to keymap and readme

### DIFF
--- a/packages/storage/Readme.md
+++ b/packages/storage/Readme.md
@@ -9,7 +9,7 @@ This package contains many tools related to storage access patterns. This readme
 To import this package, add one of the following lines to your `Cargo.toml` file
 
 ```toml
-secret-toolkit = { version = "0.3", default-features = false, features = ["utils", "storage", "serialization"] }
+secret-toolkit = { version = "0.4", default-features = false, features = ["utils", "storage", "serialization"] }
 ```
 
 for the release versions, or
@@ -43,7 +43,7 @@ pub static OWNER: Item<HumanAddr> = Item::new(b"owner");
 This uses Bincode2 to serde HumanAddr by default. To specify the Serde algorithm as Json, first import it from `secret-toolkit-serialization`
 
 ```ignore
-use secret_toolkit_serialization::{Bincode2, Json};
+use secret_toolkit::serialization::{Bincode2, Json};
 ```
 
 then
@@ -144,7 +144,7 @@ This is a storage wrapper based on AppendStore that replicates a double ended li
 To import and intialize this storage object as a static constant in `state.rs`, do the following:
 
 ```ignore
-use secret_toolkit_storage::{DequeStore}
+use secret_toolkit::storage::{DequeStore}
 ```
 
 ```ignore
@@ -173,7 +173,7 @@ be returned in each page.
 To import and intialize this storage object as a static constant in `state.rs`, do the following:
 
 ```ignore
-use secret_toolkit_storage::{Keymap}
+use secret_toolkit::storage::{Keymap}
 ```
 
 ```ignore
@@ -208,7 +208,7 @@ let foo = Foo {
     votes: 1111,
 };
 
-ADDR_VOTE.insert(&mut deps.storage, &user_addr, foo.clone())?;
+ADDR_VOTE.insert(&mut deps.storage, &user_addr, &foo)?;
 // Compiler knows that this is Foo
 let read_foo = ADDR_VOTE.get(&deps.storage, &user_addr).unwrap();
 assert_eq!(read_foo, foo1);
@@ -241,8 +241,8 @@ fn test_keymap_iter_keys() -> StdResult<()> {
     let key1 = "key1".to_string();
     let key2 = "key2".to_string();
 
-    keymap.insert(&mut storage, &key1, foo1.clone())?;
-    keymap.insert(&mut storage, &key2, foo2.clone())?;
+    keymap.insert(&mut storage, &key1, &foo1)?;
+    keymap.insert(&mut storage, &key2, &foo2)?;
 
     let mut x = keymap.iter_keys(&storage)?;
     let (len, _) = x.size_hint();
@@ -270,8 +270,8 @@ fn test_keymap_iter() -> StdResult<()> {
         number: 1111,
     };
 
-    keymap.insert(&mut storage, &b"key1".to_vec(), foo1.clone())?;
-    keymap.insert(&mut storage, &b"key2".to_vec(), foo2.clone())?;
+    keymap.insert(&mut storage, &b"key1".to_vec(), &foo1)?;
+    keymap.insert(&mut storage, &b"key2".to_vec(), &foo2)?;
 
     let mut x = keymap.iter(&storage)?;
     let (len, _) = x.size_hint();

--- a/packages/storage/src/append_store.rs
+++ b/packages/storage/src/append_store.rs
@@ -194,8 +194,8 @@ impl<'a, T: Serialize + DeserializeOwned, Ser: Serde> Clone for AppendStore<'a, 
             namespace: self.namespace,
             prefix: self.prefix.clone(),
             length: Mutex::new(None),
-            item_type: self.item_type,
-            serialization_type: self.serialization_type,
+            item_type: PhantomData,
+            serialization_type: PhantomData,
         }
     }
 }

--- a/packages/storage/src/append_store.rs
+++ b/packages/storage/src/append_store.rs
@@ -191,11 +191,11 @@ impl<'a, T: Serialize + DeserializeOwned, Ser: Serde> AppendStore<'a, T, Ser> {
 impl<'a, T: Serialize + DeserializeOwned, Ser: Serde> Clone for AppendStore<'a, T, Ser> {
     fn clone(&self) -> Self {
         Self {
-            namespace: self.namespace.clone(),
+            namespace: self.namespace,
             prefix: self.prefix.clone(),
             length: Mutex::new(None),
-            item_type: self.item_type.clone(),
-            serialization_type: self.serialization_type.clone(),
+            item_type: self.item_type,
+            serialization_type: self.serialization_type,
         }
     }
 }

--- a/packages/storage/src/deque_store.rs
+++ b/packages/storage/src/deque_store.rs
@@ -305,8 +305,8 @@ impl<'a, T: Serialize + DeserializeOwned, Ser: Serde> Clone for DequeStore<'a, T
             prefix: self.prefix.clone(),
             length: Mutex::new(None),
             offset: Mutex::new(None),
-            item_type: self.item_type,
-            serialization_type: self.serialization_type,
+            item_type: PhantomData,
+            serialization_type: PhantomData,
         }
     }
 }

--- a/packages/storage/src/deque_store.rs
+++ b/packages/storage/src/deque_store.rs
@@ -34,7 +34,7 @@ where
     serialization_type: PhantomData<Ser>,
 }
 
-impl<'a, 'b, T: Serialize + DeserializeOwned, Ser: Serde> DequeStore<'a, T, Ser> {
+impl<'a, T: Serialize + DeserializeOwned, Ser: Serde> DequeStore<'a, T, Ser> {
     /// constructor
     pub const fn new(prefix: &'a [u8]) -> Self {
         Self {
@@ -301,12 +301,12 @@ impl<'a, T: Serialize + DeserializeOwned, Ser: Serde> DequeStore<'a, T, Ser> {
 impl<'a, T: Serialize + DeserializeOwned, Ser: Serde> Clone for DequeStore<'a, T, Ser> {
     fn clone(&self) -> Self {
         Self {
-            namespace: self.namespace.clone(),
+            namespace: self.namespace,
             prefix: self.prefix.clone(),
             length: Mutex::new(None),
             offset: Mutex::new(None),
-            item_type: self.item_type.clone(),
-            serialization_type: self.serialization_type.clone(),
+            item_type: self.item_type,
+            serialization_type: self.serialization_type,
         }
     }
 }

--- a/packages/storage/src/item.rs
+++ b/packages/storage/src/item.rs
@@ -55,10 +55,7 @@ where
 
     /// efficient way to see if any object is currently saved.
     pub fn is_empty<S: ReadonlyStorage>(&self, storage: &S) -> bool {
-        match storage.get(self.as_slice()) {
-            Some(_) => false,
-            None => true,
-        }
+        storage.get(self.as_slice()).is_none()
     }
 
     /// Loads the data, perform the specified action, and store the result

--- a/packages/storage/src/keymap.rs
+++ b/packages/storage/src/keymap.rs
@@ -442,9 +442,9 @@ impl<'a, K: Serialize + DeserializeOwned, T: Serialize + DeserializeOwned, Ser: 
             namespace: self.namespace,
             prefix: self.prefix.clone(),
             length: Mutex::new(None),
-            key_type: self.key_type,
-            item_type: self.item_type,
-            serialization_type: self.serialization_type,
+            key_type: PhantomData,
+            item_type: PhantomData,
+            serialization_type: PhantomData,
         }
     }
 }

--- a/packages/storage/src/keymap.rs
+++ b/packages/storage/src/keymap.rs
@@ -439,12 +439,12 @@ impl<'a, K: Serialize + DeserializeOwned, T: Serialize + DeserializeOwned, Ser: 
 {
     fn clone(&self) -> Self {
         Self {
-            namespace: self.namespace.clone(),
+            namespace: self.namespace,
             prefix: self.prefix.clone(),
             length: Mutex::new(None),
-            key_type: self.key_type.clone(),
-            item_type: self.item_type.clone(),
-            serialization_type: self.serialization_type.clone(),
+            key_type: self.key_type,
+            item_type: self.item_type,
+            serialization_type: self.serialization_type,
         }
     }
 }


### PR DESCRIPTION
Keymap's insert method is now modified to take a reference to the item instead of taking ownership of the item. Some clippy errors are fixed (there are still some warnings). Minor changes to readme