### PR TITLE
Dev v0.5

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -1,5 +1,17 @@
 # Release notes for the Secret Toolkit
 
+## v0.5.0
+This release includes some minor fixed to the storage package which required some breaking changes.
+We are releasing these breaking changes because we reached the conclusion that the current interfaces
+are prone to bugs, or inefficient. Unless you are using these specific interfaces, you should be able to upgrade from 0.4 without issues.
+
+### Breaking
+- Removed the implementations of Clone for storage types which are not useful and may cause data corruption if used incorrectly.
+- Changed `Keymap::insert` to take the item by reference rather than by value. This should reduce the cost of calling that function by avoiding cloning.
+
+### Features
+- Changed the implementation of the `add_prefix` methods in the storage package to use length prefixing, which should help avoid namespace collisions.
+
 ## secret-toolkit-storage v0.4.2
 
 * BUGFIX: implementation of `.clone` method fixed

--- a/packages/snip20/src/query.rs
+++ b/packages/snip20/src/query.rs
@@ -241,6 +241,7 @@ pub enum AuthenticatedQueryResponse {
         msg: String,
     },
 }
+
 /// wrapper to deserialize TokenInfo response
 #[derive(Deserialize)]
 pub struct TokenInfoResponse {

--- a/packages/storage/Cargo.toml
+++ b/packages/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secret-toolkit-storage"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2018"
 authors = ["SCRT Labs <info@scrtlabs.com>"]
 license-file = "../../LICENSE"

--- a/packages/storage/src/append_store.rs
+++ b/packages/storage/src/append_store.rs
@@ -41,6 +41,7 @@ impl<'a, T: Serialize + DeserializeOwned, Ser: Serde> AppendStore<'a, T, Ser> {
             serialization_type: PhantomData,
         }
     }
+
     /// This is used to produce a new AppendListStorage. This can be used when you want to associate an AppendListStorage to each user
     /// and you still get to define the AppendListStorage as a static constant
     pub fn add_suffix(&self, suffix: &[u8]) -> Self {
@@ -82,10 +83,12 @@ impl<'a, T: Serialize + DeserializeOwned, Ser: Serde> AppendStore<'a, T, Ser> {
             }
         }
     }
+
     /// checks if the collection has any elements
     pub fn is_empty<S: ReadonlyStorage>(&self, storage: &S) -> StdResult<bool> {
         Ok(self.get_len(storage)? == 0)
     }
+
     /// gets the element at pos if within bounds
     pub fn get_at<S: ReadonlyStorage>(&self, storage: &S, pos: u32) -> StdResult<T> {
         let len = self.get_len(storage)?;
@@ -94,6 +97,7 @@ impl<'a, T: Serialize + DeserializeOwned, Ser: Serde> AppendStore<'a, T, Ser> {
         }
         self.get_at_unchecked(storage, pos)
     }
+
     /// tries to get the element at pos
     fn get_at_unchecked<S: ReadonlyStorage>(&self, storage: &S, pos: u32) -> StdResult<T> {
         let key = pos.to_be_bytes();
@@ -108,10 +112,12 @@ impl<'a, T: Serialize + DeserializeOwned, Ser: Serde> AppendStore<'a, T, Ser> {
         let mut may_len = self.length.lock().unwrap();
         *may_len = Some(len);
     }
+
     /// Clear the collection
     pub fn clear<S: Storage>(&self, storage: &mut S) {
         self.set_len(storage, 0);
     }
+
     /// Replaces data at a position within bounds
     pub fn set_at<S: Storage>(&self, storage: &mut S, pos: u32, item: &T) -> StdResult<()> {
         let len = self.get_len(storage)?;
@@ -120,10 +126,12 @@ impl<'a, T: Serialize + DeserializeOwned, Ser: Serde> AppendStore<'a, T, Ser> {
         }
         self.set_at_unchecked(storage, pos, item)
     }
+
     /// Sets data at a given index
     fn set_at_unchecked<S: Storage>(&self, storage: &mut S, pos: u32, item: &T) -> StdResult<()> {
         self.save_impl(storage, &pos.to_be_bytes(), item)
     }
+
     /// Pushes an item to AppendStorage
     pub fn push<S: Storage>(&self, storage: &mut S, item: &T) -> StdResult<()> {
         let len = self.get_len(storage)?;
@@ -131,6 +139,7 @@ impl<'a, T: Serialize + DeserializeOwned, Ser: Serde> AppendStore<'a, T, Ser> {
         self.set_len(storage, len + 1);
         Ok(())
     }
+
     /// Pops an item from AppendStore
     pub fn pop<S: Storage>(&self, storage: &mut S) -> StdResult<T> {
         if let Some(len) = self.get_len(storage)?.checked_sub(1) {
@@ -141,6 +150,7 @@ impl<'a, T: Serialize + DeserializeOwned, Ser: Serde> AppendStore<'a, T, Ser> {
             Err(StdError::generic_err("Can not pop from empty AppendStore"))
         }
     }
+
     /// Remove an element from the collection at the specified position.
     ///
     /// Removing the last element has a constant cost.
@@ -164,6 +174,7 @@ impl<'a, T: Serialize + DeserializeOwned, Ser: Serde> AppendStore<'a, T, Ser> {
         self.set_len(storage, len - 1);
         item
     }
+
     /// Returns a readonly iterator
     pub fn iter<S: ReadonlyStorage>(
         &self,
@@ -173,6 +184,7 @@ impl<'a, T: Serialize + DeserializeOwned, Ser: Serde> AppendStore<'a, T, Ser> {
         let iter = AppendStoreIter::new(self, storage, 0, len);
         Ok(iter)
     }
+
     /// does paging with the given parameters
     pub fn paging<S: ReadonlyStorage>(
         &self,

--- a/packages/storage/src/append_store.rs
+++ b/packages/storage/src/append_store.rs
@@ -375,7 +375,7 @@ mod tests {
         let append_store: AppendStore<i32> = AppendStore::new(b"test");
 
         assert!(append_store.length.lock().unwrap().eq(&None));
-        assert_eq!(append_store.get_len(&mut storage)?, 0);
+        assert_eq!(append_store.get_len(&storage)?, 0);
         assert!(append_store.length.lock().unwrap().eq(&Some(0)));
 
         append_store.push(&mut storage, &1234)?;
@@ -383,21 +383,21 @@ mod tests {
         append_store.push(&mut storage, &3412)?;
         append_store.push(&mut storage, &4321)?;
         assert!(append_store.length.lock().unwrap().eq(&Some(4)));
-        assert_eq!(append_store.get_len(&mut storage)?, 4);
+        assert_eq!(append_store.get_len(&storage)?, 4);
 
         assert_eq!(append_store.pop(&mut storage), Ok(4321));
         assert_eq!(append_store.pop(&mut storage), Ok(3412));
         assert!(append_store.length.lock().unwrap().eq(&Some(2)));
-        assert_eq!(append_store.get_len(&mut storage)?, 2);
+        assert_eq!(append_store.get_len(&storage)?, 2);
 
         assert_eq!(append_store.pop(&mut storage), Ok(2143));
         assert_eq!(append_store.pop(&mut storage), Ok(1234));
         assert!(append_store.length.lock().unwrap().eq(&Some(0)));
-        assert_eq!(append_store.get_len(&mut storage)?, 0);
+        assert_eq!(append_store.get_len(&storage)?, 0);
 
         assert!(append_store.pop(&mut storage).is_err());
         assert!(append_store.length.lock().unwrap().eq(&Some(0)));
-        assert_eq!(append_store.get_len(&mut storage)?, 0);
+        assert_eq!(append_store.get_len(&storage)?, 0);
 
         Ok(())
     }

--- a/packages/storage/src/append_store.rs
+++ b/packages/storage/src/append_store.rs
@@ -47,8 +47,7 @@ impl<'a, T: Serialize + DeserializeOwned, Ser: Serde> AppendStore<'a, T, Ser> {
     /// and you still get to define the AppendListStorage as a static constant
     pub fn add_suffix(&self, suffix: &[u8]) -> Self {
         let suffix = to_length_prefixed(suffix);
-        let prefix = self.prefix.as_ref().map(Vec::as_slice);
-        let prefix = prefix.unwrap_or(self.namespace);
+        let prefix = self.prefix.as_deref().unwrap_or(self.namespace);
         let prefix = [prefix, suffix.as_slice()].concat();
         Self {
             namespace: self.namespace,

--- a/packages/storage/src/append_store.rs
+++ b/packages/storage/src/append_store.rs
@@ -199,18 +199,6 @@ impl<'a, T: Serialize + DeserializeOwned, Ser: Serde> AppendStore<'a, T, Ser> {
     }
 }
 
-impl<'a, T: Serialize + DeserializeOwned, Ser: Serde> Clone for AppendStore<'a, T, Ser> {
-    fn clone(&self) -> Self {
-        Self {
-            namespace: self.namespace,
-            prefix: self.prefix.clone(),
-            length: Mutex::new(None),
-            item_type: PhantomData,
-            serialization_type: PhantomData,
-        }
-    }
-}
-
 impl<'a, T: Serialize + DeserializeOwned, Ser: Serde> AppendStore<'a, T, Ser> {
     fn as_slice(&self) -> &[u8] {
         if let Some(prefix) = &self.prefix {

--- a/packages/storage/src/deque_store.rs
+++ b/packages/storage/src/deque_store.rs
@@ -51,8 +51,7 @@ impl<'a, T: Serialize + DeserializeOwned, Ser: Serde> DequeStore<'a, T, Ser> {
     /// and you still get to define the DequeStorage as a static constant
     pub fn add_suffix(&self, suffix: &[u8]) -> Self {
         let suffix = to_length_prefixed(suffix);
-        let prefix = self.prefix.as_ref().map(Vec::as_slice);
-        let prefix = prefix.unwrap_or(self.namespace);
+        let prefix = self.prefix.as_deref().unwrap_or(self.namespace);
         let prefix = [prefix, suffix.as_slice()].concat();
         Self {
             namespace: self.namespace,

--- a/packages/storage/src/deque_store.rs
+++ b/packages/storage/src/deque_store.rs
@@ -317,19 +317,6 @@ impl<'a, T: Serialize + DeserializeOwned, Ser: Serde> DequeStore<'a, T, Ser> {
     }
 }
 
-impl<'a, T: Serialize + DeserializeOwned, Ser: Serde> Clone for DequeStore<'a, T, Ser> {
-    fn clone(&self) -> Self {
-        Self {
-            namespace: self.namespace,
-            prefix: self.prefix.clone(),
-            length: Mutex::new(None),
-            offset: Mutex::new(None),
-            item_type: PhantomData,
-            serialization_type: PhantomData,
-        }
-    }
-}
-
 /// An iterator over the contents of the deque store.
 pub struct DequeStoreIter<'a, T, S, Ser>
 where

--- a/packages/storage/src/deque_store.rs
+++ b/packages/storage/src/deque_store.rs
@@ -12,6 +12,7 @@ use std::sync::Mutex;
 use serde::{de::DeserializeOwned, Serialize};
 
 use cosmwasm_std::{ReadonlyStorage, StdError, StdResult, Storage};
+use cosmwasm_storage::to_length_prefixed;
 
 use secret_toolkit_serialization::{Bincode2, Serde};
 
@@ -49,11 +50,10 @@ impl<'a, T: Serialize + DeserializeOwned, Ser: Serde> DequeStore<'a, T, Ser> {
     /// This is used to produce a new DequeStorage. This can be used when you want to associate an AppendListStorage to each user
     /// and you still get to define the DequeStorage as a static constant
     pub fn add_suffix(&self, suffix: &[u8]) -> Self {
-        let prefix = if let Some(prefix) = &self.prefix {
-            [prefix.clone(), suffix.to_vec()].concat()
-        } else {
-            [self.namespace.to_vec(), suffix.to_vec()].concat()
-        };
+        let suffix = to_length_prefixed(suffix);
+        let prefix = self.prefix.as_ref().map(Vec::as_slice);
+        let prefix = prefix.unwrap_or(self.namespace);
+        let prefix = [prefix, suffix.as_slice()].concat();
         Self {
             namespace: self.namespace,
             prefix: Some(prefix),

--- a/packages/storage/src/item.rs
+++ b/packages/storage/src/item.rs
@@ -149,17 +149,6 @@ where
     }
 }
 
-impl<'a, T: Serialize + DeserializeOwned, Ser: Serde> Clone for Item<'a, T, Ser> {
-    fn clone(&self) -> Self {
-        Self {
-            storage_key: self.storage_key,
-            prefix: self.prefix.clone(),
-            item_type: PhantomData,
-            serialization_type: PhantomData,
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use cosmwasm_std::testing::MockStorage;

--- a/packages/storage/src/item.rs
+++ b/packages/storage/src/item.rs
@@ -34,8 +34,7 @@ impl<'a, T: Serialize + DeserializeOwned, Ser: Serde> Item<'a, T, Ser> {
     /// and you still get to define the Item as a static constant
     pub fn add_suffix(&self, suffix: &[u8]) -> Self {
         let suffix = to_length_prefixed(suffix);
-        let prefix = self.prefix.as_ref().map(Vec::as_slice);
-        let prefix = prefix.unwrap_or(self.storage_key);
+        let prefix = self.prefix.as_deref().unwrap_or(self.storage_key);
         let prefix = [prefix, suffix.as_slice()].concat();
         Self {
             storage_key: self.storage_key,

--- a/packages/storage/src/item.rs
+++ b/packages/storage/src/item.rs
@@ -28,6 +28,7 @@ impl<'a, T: Serialize + DeserializeOwned, Ser: Serde> Item<'a, T, Ser> {
             serialization_type: PhantomData,
         }
     }
+
     /// This is used to produce a new Item. This can be used when you want to associate an Item to each user
     /// and you still get to define the Item as a static constant
     pub fn add_suffix(&self, suffix: &[u8]) -> Self {

--- a/packages/storage/src/keymap.rs
+++ b/packages/storage/src/keymap.rs
@@ -7,6 +7,7 @@ use serde::Deserialize;
 use serde::{de::DeserializeOwned, Serialize};
 
 use cosmwasm_std::{ReadonlyStorage, StdError, StdResult, Storage};
+use cosmwasm_storage::to_length_prefixed;
 
 use secret_toolkit_serialization::{Bincode2, Serde};
 
@@ -79,11 +80,10 @@ impl<'a, K: Serialize + DeserializeOwned, T: Serialize + DeserializeOwned, Ser: 
     /// This is used to produce a new Keymap. This can be used when you want to associate an Keymap to each user
     /// and you still get to define the Keymap as a static constant
     pub fn add_suffix(&self, suffix: &[u8]) -> Self {
-        let prefix = if let Some(prefix) = &self.prefix {
-            [prefix.clone(), suffix.to_vec()].concat()
-        } else {
-            [self.namespace.to_vec(), suffix.to_vec()].concat()
-        };
+        let suffix = to_length_prefixed(suffix);
+        let prefix = self.prefix.as_ref().map(Vec::as_slice);
+        let prefix = prefix.unwrap_or(self.namespace);
+        let prefix = [prefix, suffix.as_slice()].concat();
         Self {
             namespace: self.namespace,
             prefix: Some(prefix),

--- a/packages/storage/src/keymap.rs
+++ b/packages/storage/src/keymap.rs
@@ -75,6 +75,7 @@ impl<'a, K: Serialize + DeserializeOwned, T: Serialize + DeserializeOwned, Ser: 
             serialization_type: PhantomData,
         }
     }
+
     /// This is used to produce a new Keymap. This can be used when you want to associate an Keymap to each user
     /// and you still get to define the Keymap as a static constant
     pub fn add_suffix(&self, suffix: &[u8]) -> Self {
@@ -101,10 +102,12 @@ impl<'a, K: Serialize + DeserializeOwned, T: Serialize + DeserializeOwned, Ser: 
     fn serialize_key(&self, key: &K) -> StdResult<Vec<u8>> {
         Ser::serialize(key)
     }
+
     /// Deserialize key
     fn deserialize_key(&self, key_data: &[u8]) -> StdResult<K> {
         Ser::deserialize(key_data)
     }
+
     /// get total number of objects saved
     pub fn get_len<S: ReadonlyStorage>(&self, storage: &S) -> StdResult<u32> {
         let mut may_len = self.length.lock().unwrap();
@@ -127,10 +130,12 @@ impl<'a, K: Serialize + DeserializeOwned, T: Serialize + DeserializeOwned, Ser: 
             }
         }
     }
+
     /// checks if the collection has any elements
     pub fn is_empty<S: ReadonlyStorage>(&self, storage: &S) -> StdResult<bool> {
         Ok(self.get_len(storage)? == 0)
     }
+
     /// set length of the map
     fn set_len<S: Storage>(&self, storage: &mut S, len: u32) -> StdResult<()> {
         let len_key = [self.as_slice(), MAP_LENGTH].concat();
@@ -141,6 +146,7 @@ impl<'a, K: Serialize + DeserializeOwned, T: Serialize + DeserializeOwned, Ser: 
 
         Ok(())
     }
+
     /// Used to get the indexes stored in the given page number
     fn _get_indexes<S: ReadonlyStorage>(&self, storage: &S, page: u32) -> StdResult<Vec<Vec<u8>>> {
         let indexes_key = [self.as_slice(), INDEXES, page.to_be_bytes().as_slice()].concat();
@@ -150,6 +156,7 @@ impl<'a, K: Serialize + DeserializeOwned, T: Serialize + DeserializeOwned, Ser: 
             None => Ok(vec![]),
         }
     }
+
     /// Set an indexes page
     fn _set_indexes_page<S: Storage>(
         &self,
@@ -161,6 +168,7 @@ impl<'a, K: Serialize + DeserializeOwned, T: Serialize + DeserializeOwned, Ser: 
         storage.set(&indexes_key, &Bincode2::serialize(indexes)?);
         Ok(())
     }
+
     /// user facing get function
     pub fn get<S: ReadonlyStorage>(&self, storage: &S, key: &K) -> Option<T> {
         if let Ok(internal_item) = self._get_from_key(storage, key) {
@@ -169,6 +177,7 @@ impl<'a, K: Serialize + DeserializeOwned, T: Serialize + DeserializeOwned, Ser: 
             None
         }
     }
+
     /// internal item get function
     fn _get_from_key<S: ReadonlyStorage>(
         &self,
@@ -178,6 +187,7 @@ impl<'a, K: Serialize + DeserializeOwned, T: Serialize + DeserializeOwned, Ser: 
         let key_vec = self.serialize_key(key)?;
         self.load_impl(storage, &key_vec)
     }
+
     /// user facing remove function
     pub fn remove<S: Storage>(&self, storage: &mut S, key: &K) -> StdResult<()> {
         let key_vec = self.serialize_key(key)?;
@@ -238,6 +248,7 @@ impl<'a, K: Serialize + DeserializeOwned, T: Serialize + DeserializeOwned, Ser: 
 
         Ok(())
     }
+
     /// user facing insert function
     pub fn insert<S: Storage>(&self, storage: &mut S, key: &K, item: T) -> StdResult<()> {
         let key_vec = self.serialize_key(key)?;
@@ -262,6 +273,7 @@ impl<'a, K: Serialize + DeserializeOwned, T: Serialize + DeserializeOwned, Ser: 
             }
         }
     }
+
     /// user facing method that checks if any item is stored with this key.
     pub fn contains<S: ReadonlyStorage>(&self, storage: &S, key: &K) -> bool {
         match self.serialize_key(key) {
@@ -269,6 +281,7 @@ impl<'a, K: Serialize + DeserializeOwned, T: Serialize + DeserializeOwned, Ser: 
             Err(_) => false,
         }
     }
+
     /// paginates (key, item) pairs.
     pub fn paging<S: ReadonlyStorage>(
         &self,
@@ -295,6 +308,7 @@ impl<'a, K: Serialize + DeserializeOwned, T: Serialize + DeserializeOwned, Ser: 
         }
         self.get_pairs_at_positions(storage, start_pos, end_pos)
     }
+
     /// paginates only the keys. More efficient than paginating both items and keys
     pub fn paging_keys<S: ReadonlyStorage>(
         &self,
@@ -321,6 +335,7 @@ impl<'a, K: Serialize + DeserializeOwned, T: Serialize + DeserializeOwned, Ser: 
         }
         self.get_keys_at_positions(storage, start_pos, end_pos)
     }
+
     /// tries to list keys without checking start/end bounds
     fn get_keys_at_positions<S: ReadonlyStorage>(
         &self,
@@ -353,6 +368,7 @@ impl<'a, K: Serialize + DeserializeOwned, T: Serialize + DeserializeOwned, Ser: 
         }
         Ok(res)
     }
+
     /// tries to list (key, item) pairs without checking start/end bounds
     fn get_pairs_at_positions<S: ReadonlyStorage>(
         &self,
@@ -386,6 +402,7 @@ impl<'a, K: Serialize + DeserializeOwned, T: Serialize + DeserializeOwned, Ser: 
         }
         Ok(res)
     }
+
     /// gets a key from a specific position in indexes
     fn get_key_from_pos<S: ReadonlyStorage>(&self, storage: &S, pos: u32) -> StdResult<K> {
         let page = _page_from_position(pos);
@@ -394,6 +411,7 @@ impl<'a, K: Serialize + DeserializeOwned, T: Serialize + DeserializeOwned, Ser: 
         let key_vec = &indexes[index as usize];
         self.deserialize_key(key_vec)
     }
+
     /// gets a key from a specific position in indexes
     fn get_pair_from_pos<S: ReadonlyStorage>(&self, storage: &S, pos: u32) -> StdResult<(K, T)> {
         let page = _page_from_position(pos);
@@ -404,6 +422,7 @@ impl<'a, K: Serialize + DeserializeOwned, T: Serialize + DeserializeOwned, Ser: 
         let item = self.load_impl(storage, key_vec)?.get_item()?;
         Ok((key, item))
     }
+
     /// Returns a readonly iterator only for keys. More efficient than iter().
     pub fn iter_keys<S: ReadonlyStorage>(
         &self,
@@ -413,6 +432,7 @@ impl<'a, K: Serialize + DeserializeOwned, T: Serialize + DeserializeOwned, Ser: 
         let iter = KeyIter::new(self, storage, 0, len);
         Ok(iter)
     }
+
     /// Returns a readonly iterator for (key-item) pairs
     pub fn iter<S: ReadonlyStorage>(&self, storage: &'a S) -> StdResult<KeyItemIter<K, T, S, Ser>> {
         let len = self.get_len(storage)?;

--- a/packages/storage/src/keymap.rs
+++ b/packages/storage/src/keymap.rs
@@ -452,21 +452,6 @@ impl<'a, K: Serialize + DeserializeOwned, T: Serialize + DeserializeOwned, Ser: 
     }
 }
 
-impl<'a, K: Serialize + DeserializeOwned, T: Serialize + DeserializeOwned, Ser: Serde> Clone
-    for Keymap<'a, K, T, Ser>
-{
-    fn clone(&self) -> Self {
-        Self {
-            namespace: self.namespace,
-            prefix: self.prefix.clone(),
-            length: Mutex::new(None),
-            key_type: PhantomData,
-            item_type: PhantomData,
-            serialization_type: PhantomData,
-        }
-    }
-}
-
 /// An iterator over the keys of the Keymap.
 pub struct KeyIter<'a, K, T, S, Ser>
 where

--- a/packages/storage/src/keymap.rs
+++ b/packages/storage/src/keymap.rs
@@ -81,8 +81,7 @@ impl<'a, K: Serialize + DeserializeOwned, T: Serialize + DeserializeOwned, Ser: 
     /// and you still get to define the Keymap as a static constant
     pub fn add_suffix(&self, suffix: &[u8]) -> Self {
         let suffix = to_length_prefixed(suffix);
-        let prefix = self.prefix.as_ref().map(Vec::as_slice);
-        let prefix = prefix.unwrap_or(self.namespace);
+        let prefix = self.prefix.as_deref().unwrap_or(self.namespace);
         let prefix = [prefix, suffix.as_slice()].concat();
         Self {
             namespace: self.namespace,

--- a/packages/toolkit/Cargo.toml
+++ b/packages/toolkit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secret-toolkit"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2018"
 authors = ["SCRT Labs <info@scrtlabs.com>"]
 license-file = "../../LICENSE"
@@ -33,6 +33,6 @@ secret-toolkit-permit = { version = "0.3.0", path = "../permit", optional = true
 secret-toolkit-serialization = { version = "0.3", path = "../serialization", optional = true }
 secret-toolkit-snip20 = { version = "0.3", path = "../snip20", optional = true }
 secret-toolkit-snip721 = { version = "0.3", path = "../snip721", optional = true }
-secret-toolkit-storage = { version = "0.4", path = "../storage", optional = true }
+secret-toolkit-storage = { version = "0.5", path = "../storage", optional = true }
 secret-toolkit-utils = { version = "0.3", path = "../utils", optional = true }
 secret-toolkit-viewing-key = { version = "0.3", path = "../viewing_key", optional = true }


### PR DESCRIPTION
This PR:
- Removes the implementations of Clone for storage types which are not useful and may cause data corruption if used incorrectly.
- Changes the implementation of the `add_prefix` methods in the storage package to use length prefixing, which should help avoid namespace collisions
- Changes `Keymap::insert` to take the item by reference rather than by value. This is an API-changing bugfix, and aligns it with the implementation in #51 