### PR TITLE
Storage v0.5.1 Upgrade with Minor Clippy Fixes and Readme Updates (Cosmwasm v1.0 Branch)

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -3,7 +3,7 @@
 ## secret-toolkit-storage v0.5.1
 
 - Added the `Keyset` storage object (A hashset like storage object).
-- Allowed further customization of Keymap and Keyset with new constructor structs called `KeymapBuilder` and `KeysetBuilder` which allow the user to disable the iterator feature (saving gas) or adjust the internal indexes' page size so that the user may determine how many objects are to be stored/loaded together in the iterator.
+- Allowed further customisation of Keymap and Keyset with new constructor structs called `KeymapBuilder` and `KeysetBuilder` which allow the user to disable the iterator feature (saving gas) or adjust the internal indexes' page size so that the user may determine how many objects are to be stored/loaded together in the iterator.
 - `::new_with_page_size(namespace, page_size)` method was added to `AppendStore` and `DequeStore` so that the user may adjust the internal indexes' page size which determine how many objects are to be stored/loaded together in the iterator.
 - Minor performance upgrades to `Keymap`, `AppendStore`, and `DequeStore`.
 

--- a/Releases.md
+++ b/Releases.md
@@ -5,7 +5,7 @@
 - Added the `Keyset` storage object (A hashset like storage object).
 - Allowed further customization of Keymap and Keyset with new constructor structs called `KeymapBuilder` and `KeysetBuilder` which allow the user to disable the iterator feature (saving gas) or adjust the internal indexes' page size so that the user may determine how many objects are to be stored/loaded together in the iterator.
 - `::new_with_page_size(namespace, page_size)` method was added to `AppendStore` and `DequeStore` so that the user may adjust the internal indexes' page size which determine how many objects are to be stored/loaded together in the iterator.
-- Minor performance upgrades to `Keyset`, `AppendStore`, and `DequeStore`.
+- Minor performance upgrades to `Keymap`, `AppendStore`, and `DequeStore`.
 
 ## v0.5.0
 

--- a/Releases.md
+++ b/Releases.md
@@ -1,5 +1,10 @@
 # Release notes for the Secret Toolkit
 
+## secret-toolkit-storage v0.5.1
+
+- Added `Keyset` storage object (A hashset like storage object).
+- Allowed further customization of Keymap and Keyset with new constructor structs called `KeymapBuilder` and `KeysetBuilder`.
+
 ## v0.5.0
 
 This release includes some minor fixed to the storage package which required some breaking changes.

--- a/Releases.md
+++ b/Releases.md
@@ -2,8 +2,10 @@
 
 ## secret-toolkit-storage v0.5.1
 
-- Added `Keyset` storage object (A hashset like storage object).
-- Allowed further customization of Keymap and Keyset with new constructor structs called `KeymapBuilder` and `KeysetBuilder`.
+- Added the `Keyset` storage object (A hashset like storage object).
+- Allowed further customization of Keymap and Keyset with new constructor structs called `KeymapBuilder` and `KeysetBuilder` which allow the user to disable the iterator feature (saving gas) or adjust the internal indexes' page size so that the user may determine how many objects are to be stored/loaded together in the iterator.
+- `::new_with_page_size(namespace, page_size)` method was added to `AppendStore` and `DequeStore` so that the user may adjust the internal indexes' page size which determine how many objects are to be stored/loaded together in the iterator.
+- Minor performance upgrades to `Keyset`, `AppendStore`, and `DequeStore`.
 
 ## v0.5.0
 

--- a/packages/incubator/Readme.md
+++ b/packages/incubator/Readme.md
@@ -4,50 +4,11 @@
 
 This package contains tools that are not yet final and may change or contain unknown bugs, and are pending more testing or reviews.
 
-## Cashmap
-
-A hashmap-like structure, that allows iteration with paging over keys without guaranteed ordering.
-An example use-case for such a structure is if you want to contain a large amount of votes, deposits, or bets and iterate over them at some time in the future.
-Since iterating over large amounts of data at once may be prohibitive, this structure allows you to specify the amount of data that will
-be returned in each page.
-
-This structure may also be used as a hashmap structure without the fancy bells and whistles, though gas-costs will be more expensive than simple storage.
-
-### Usage
-
-#### Initialization
-
-You can open/initialize the cashmap directly using 
-
-```rust
-let mut storage = MockStorage::new();
-let mut cmap = CashMap::init(b"cashmap-name", &mut storage);
-```
-
-#### Access pattern
-
-Todo: improve this section
-
-```rust
-let foo1 = Foo {
-    string: "string one".to_string(),
-    number: 1111,
-};
-
-cmap.insert(b"key1", foo1.clone())?;
-let read_foo1 = cmap.get(b"key1").unwrap();
-cmap.remove(b"key1")?;
-```
-
-### Todo
-
-Generalize keys to allow any hashable type, not just &[u8]
-
 ## Max heap storage
 
 A "max heap store" is a storage wrapper that implements a binary tree maxheap data structure.
-https://en.wikipedia.org/wiki/Min-max_heap
-Implementation based on https://algorithmtutor.com/Data-Structures/Tree/Binary-Heaps/
+<https://en.wikipedia.org/wiki/Min-max_heap>
+Implementation based on <https://algorithmtutor.com/Data-Structures/Tree/Binary-Heaps/>
 
 * Insertion O(log n)
 * Remove max O(log n)
@@ -135,7 +96,7 @@ assert_eq!(heap_store.remove(), Ok(Tx{
 
 Also known as a slot map, a generational index storage is an iterable data structure where each element in the list is identified by a unique key that is a pair (index, generation). Each time an item is removed from the list the generation of the storage increments by one. If a new item is placed at the same index as a previous item which had been removed previously, the old references will not point to the new element. This is because although the index matches, the generation does not. This ensures that each reference to an element in the list is stable and safe.
 
-Starting with an empty set, if we insert A we will have key: (index: 0, generation: 0). Inserting B will have the key: (index: 1, generation: 0). When we remove A the generation will increment by 1 and index 0 will be freed up. When we insert C it will go to the head of our list of free slots and be given the key (index: 0, generation: 1). If you attempt to get A the result will be None, even though A and C have both been at "0" position in the list. 
+Starting with an empty set, if we insert A we will have key: (index: 0, generation: 0). Inserting B will have the key: (index: 1, generation: 0). When we remove A the generation will increment by 1 and index 0 will be freed up. When we insert C it will go to the head of our list of free slots and be given the key (index: 0, generation: 1). If you attempt to get A the result will be None, even though A and C have both been at "0" position in the list.
 
 Unlike AppendStore, iteration over a generational index storage is not in order of insertion.
 

--- a/packages/incubator/src/generational_store.rs
+++ b/packages/incubator/src/generational_store.rs
@@ -881,7 +881,7 @@ mod tests {
         assert_eq!(gen_store.get(delta.clone()), Some(String::from("Delta")));
         // check that the generation has updated
         assert_ne!(
-            delta.clone(),
+            delta,
             Index {
                 index: 1,
                 generation: 0

--- a/packages/snip20/Readme.md
+++ b/packages/snip20/Readme.md
@@ -11,13 +11,14 @@ You can create a HandleMsg variant and call the `to_cosmos_msg` function to gene
 Or you can call the individual function for each Handle message to generate the appropriate callback CosmosMsg.
 
 Example:
+
 ```rust
-    let recipient = HumanAddr("ADDRESS_TO_TRANSFER_TO".to_string());
+    let recipient = "ADDRESS_TO_TRANSFER_TO".to_string();
     let amount = Uint128(10000);
     let padding = None;
     let block_size = 256;
     let callback_code_hash = "TOKEN_CONTRACT_CODE_HASH".to_string();
-    let contract_addr = HumanAddr("TOKEN_CONTRACT_ADDRESS".to_string());
+    let contract_addr = "TOKEN_CONTRACT_ADDRESS".to_string();
 
     let cosmos_msg = transfer_msg(
         recipient,
@@ -28,12 +29,9 @@ Example:
         contract_addr,
     )?;
 
-    Ok(HandleResponse {
-        messages: vec![cosmos_msg],
-        log: vec![],
-        data: None,
-    })
+    Ok(Response::new().add_message(cosmos_msg))
 ```
+
 All you have to do to call a SNIP-20 Handle function is call the appropriate toolkit function, and place the resulting `CosmosMsg` in the `messages` Vec of the InitResponse or HandleResponse.  In this example, we are transferring 10000 (in the lowest denomination of the token) to the recipient address.  We are not using the `padding` field of the Transfer message, but instead, we are padding the entire message to blocks of 256 bytes.
 
 You probably have also noticed that CreateViewingKey is not supported.  This is because a contract can not see the viewing key that is returned because it has already finished executing by the time CreateViewingKey would be called.  If a contract needs to have a viewing key, it must create its own sufficiently complex viewing key, and pass it as a parameter to SetViewingKey. You can see an example of creating a complex viewing key in the [Snip20 Reference Implementation](http://github.com/enigmampc/snip20-reference-impl).  It is also highly recommended that you use the block_size padding option to mask the length of the viewing key your contract has generated.
@@ -41,6 +39,7 @@ You probably have also noticed that CreateViewingKey is not supported.  This is 
 ## Queries
 
 These are the types that SNIP20 tokens can return from queries
+
 ```rust
 pub struct TokenInfo {
     pub name: String,
@@ -56,8 +55,8 @@ pub struct ExchangeRate {
 }
 
 pub struct Allowance {
-    pub spender: HumanAddr,
-    pub owner: HumanAddr,
+    pub spender: String,
+    pub owner: String,
     pub allowance: Uint128,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expiration: Option<u64>,
@@ -69,9 +68,9 @@ pub struct Balance {
 
 pub struct Tx {
     pub id: u64,
-    pub from: HumanAddr,
-    pub sender: HumanAddr,
-    pub receiver: HumanAddr,
+    pub from: String,
+    pub sender: String,
+    pub receiver: String,
     pub coins: Coin,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub memo: Option<String>,
@@ -87,17 +86,17 @@ pub struct TransferHistory {
 #[serde(rename_all = "snake_case")]
 pub enum TxAction {
     Transfer {
-        from: HumanAddr,
-        sender: HumanAddr,
-        recipient: HumanAddr,
+        from: String,
+        sender: String,
+        recipient: String,
     },
     Mint {
-        minter: HumanAddr,
-        recipient: HumanAddr,
+        minter: String,
+        recipient: String,
     },
     Burn {
-        burner: HumanAddr,
-        owner: HumanAddr,
+        burner: String,
+        owner: String,
     },
     Deposit {},
     Redeem {},
@@ -119,22 +118,25 @@ pub struct TransactionHistory {
 }
 
 pub struct Minters {
-    pub minters: Vec<HumanAddr>,
+    pub minters: Vec<String>,
 }
 ```
+
 You can create a QueryMsg variant and call the `query` function to query a SNIP20 token contract.
 
 Or you can call the individual function for each query.
 
 Example:
+
 ```rust
-    let address = HumanAddr("ADDRESS_WHOSE_BALANCE_IS_BEING_REQUESTED".to_string());
+    let address = "ADDRESS_WHOSE_BALANCE_IS_BEING_REQUESTED".to_string();
     let key = "THE_VIEWING_KEY_PREVIOUSLY_SET_BY_THE_ADDRESS".to_string();
     let block_size = 256;
     let callback_code_hash = "TOKEN_CONTRACT_CODE_HASH".to_string();
-    let contract_addr = HumanAddr("TOKEN_CONTRACT_ADDRESS".to_string());
+    let contract_addr = "TOKEN_CONTRACT_ADDRESS".to_string();
 
     let balance =
-        balance_query(&deps.querier, address, key, block_size, callback_code_hash, contract_addr)?;
+        balance_query(deps.querier, address, key, block_size, callback_code_hash, contract_addr)?;
 ```
+
 In this example, we are doing a Balance query for the specified address/key pair and storing the response in the balance variable, which is of the Balance type defined above.  The query message is padded to blocks of 256 bytes.

--- a/packages/snip721/Readme.md
+++ b/packages/snip721/Readme.md
@@ -11,14 +11,15 @@ You can create a HandleMsg variant and call the `to_cosmos_msg` function to gene
 Or you can call the individual function for each Handle message to generate the appropriate callback CosmosMsg.
 
 Example:
+
 ```rust
-    let recipient = HumanAddr("ADDRESS_TO_TRANSFER_TO".to_string());
+    let recipient = "ADDRESS_TO_TRANSFER_TO".to_string();
     let token_id = "TOKEN_ID".to_string();
     let memo = Some("TRANSFER_MEMO".to_string());
     let padding = None;
     let block_size = 256;
     let callback_code_hash = "TOKEN_CONTRACT_CODE_HASH".to_string();
-    let contract_addr = HumanAddr("TOKEN_CONTRACT_ADDRESS".to_string());
+    let contract_addr = "TOKEN_CONTRACT_ADDRESS".to_string();
 
     let cosmos_msg = transfer_nft_msg(
         recipient,
@@ -30,12 +31,9 @@ Example:
         contract_addr,
     )?;
 
-    Ok(HandleResponse {
-        messages: vec![cosmos_msg],
-        log: vec![],
-        data: None,
-    })
+    Ok(Response::new().add_message(cosmos_msg))
 ```
+
 All you have to do to call a SNIP-721 Handle function is call the appropriate toolkit function, and place the resulting `CosmosMsg` in the `messages` Vec of the InitResponse or HandleResponse.  In this example, we are transferring an NFT named "TOKEN_ID" to the recipient address.  We are not using the `padding` field of the Transfer message, but instead, we are padding the entire message to blocks of 256 bytes.
 
 You probably have also noticed that CreateViewingKey is not supported.  This is because a contract can not see the viewing key that is returned because it has already finished executing by the time CreateViewingKey would be called.  If a contract needs to have a viewing key, it must create its own sufficiently complex viewing key, and pass it as a parameter to SetViewingKey. You can see an example of creating a complex viewing key in the [Snip20 Reference Implementation](http://github.com/enigmampc/snip20-reference-impl).  It is also highly recommended that you use the block_size padding option to mask the length of the viewing key your contract has generated.
@@ -43,6 +41,7 @@ You probably have also noticed that CreateViewingKey is not supported.  This is 
 ## Queries
 
 These are the types that the SNIP-721 toolkit queries can return
+
 ```rust
 pub struct ContractInfo {
     pub name: String,
@@ -58,12 +57,12 @@ pub struct TokenList {
 }
 
 pub struct Cw721Approval {
-    pub spender: HumanAddr,
+    pub spender: String,
     pub expires: Expiration,
 }
 
 pub struct OwnerOf {
-    pub owner: Option<HumanAddr>,
+    pub owner: Option<String>,
     pub approvals: Vec<Cw721Approval>,
 }
 
@@ -79,14 +78,14 @@ pub struct AllNftInfo {
 }
 
 pub struct Snip721Approval {
-    pub address: HumanAddr,
+    pub address: String,
     pub view_owner_expiration: Option<Expiration>,
     pub view_private_metadata_expiration: Option<Expiration>,
     pub transfer_expiration: Option<Expiration>,
 }
 
 pub struct NftDossier {
-    pub owner: Option<HumanAddr>,
+    pub owner: Option<String>,
     pub public_metadata: Option<Metadata>,
     pub private_metadata: Option<Metadata>,
     pub display_private_metadata_error: Option<String>,
@@ -120,17 +119,17 @@ pub struct InventoryApprovals {
 
 pub enum TxAction {
     Transfer {
-        from: HumanAddr,
-        sender: Option<HumanAddr>,
-        recipient: HumanAddr,
+        from: String,
+        sender: Option<String>,
+        recipient: String,
     },
     Mint {
-        minter: HumanAddr,
-        recipient: HumanAddr,
+        minter: String,
+        recipient: String,
     },
     Burn {
-        owner: HumanAddr,
-        burner: Option<HumanAddr>,
+        owner: String,
+        burner: Option<String>,
     },
 }
 
@@ -149,7 +148,7 @@ pub struct TransactionHistory {
 }
 
 pub struct Minters {
-    pub minters: Vec<HumanAddr>,
+    pub minters: Vec<String>,
 }
 
 pub struct IsUnwrapped {
@@ -161,23 +160,26 @@ pub struct VerifyTransferApproval {
     pub first_unapproved_token: Option<String>,
 }
 ```
+
 You can create a QueryMsg variant and call the `query` function to query a SNIP-721 token contract.
 
 Or you can call the individual function for each query.
 
 Example:
+
 ```rust
     let token_id = "TOKEN_ID".to_string();
     let viewer = Some(ViewerInfo {
-        address: HumanAddr("VIEWER'S_ADDRESS".to_string()),
+        address: "VIEWER'S_ADDRESS".to_string(),
         viewing_key: "VIEWER'S_KEY".to_string(),
     });
     let include_expired = None;
     let block_size = 256;
     let callback_code_hash = "TOKEN_CONTRACT_CODE_HASH".to_string();
-    let contract_addr = HumanAddr("TOKEN_CONTRACT_ADDRESS".to_string());
+    let contract_addr = "TOKEN_CONTRACT_ADDRESS".to_string();
 
     let nft_dossier =
-        nft_dossier_query(&deps.querier, token_id, viewer, include_expired, block_size, callback_code_hash, contract_addr)?;
+        nft_dossier_query(deps.querier, token_id, viewer, include_expired, block_size, callback_code_hash, contract_addr)?;
 ```
+
 In this example, we are doing an NftDossier query on the token named "TOKEN_ID", supplying the address and viewing key of the querier, and storing the response in the nft_dossier variable, which is of the NftDossier type defined above.  Because no `include_expired` was specified, the response defaults to only displaying approvals that have not expired, but approvals will only be displayed if the viewer is the owner of the token.  The query message is padded to blocks of 256 bytes.

--- a/packages/snip721/src/handle.rs
+++ b/packages/snip721/src/handle.rs
@@ -1058,7 +1058,7 @@ mod tests {
         let test_msg = approve_msg(
             spender.clone(),
             token_id.clone(),
-            expires.clone(),
+            expires,
             padding.clone(),
             256usize,
             code_hash.clone(),
@@ -1123,7 +1123,7 @@ mod tests {
 
         let test_msg = approve_all_msg(
             operator.clone(),
-            expires.clone(),
+            expires,
             padding.clone(),
             256usize,
             code_hash.clone(),
@@ -1189,7 +1189,7 @@ mod tests {
             view_owner.clone(),
             view_private_metadata.clone(),
             transfer.clone(),
-            expires.clone(),
+            expires,
             padding.clone(),
             256usize,
             code_hash.clone(),
@@ -1225,7 +1225,7 @@ mod tests {
 
         let test_msg = register_receive_nft_msg(
             code_hash.clone(),
-            also_implements_batch_receive_nft.clone(),
+            also_implements_batch_receive_nft,
             padding.clone(),
             256usize,
             callback_code_hash.clone(),
@@ -1805,7 +1805,7 @@ mod tests {
             token_id.clone(),
             view_owner.clone(),
             view_private_metadata.clone(),
-            expires.clone(),
+            expires,
             padding.clone(),
             256usize,
             code_hash.clone(),

--- a/packages/storage/Cargo.toml
+++ b/packages/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secret-toolkit-storage"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2018"
 authors = ["SCRT Labs <info@scrtlabs.com>"]
 license-file = "../../LICENSE"

--- a/packages/storage/Readme.md
+++ b/packages/storage/Readme.md
@@ -24,7 +24,7 @@ for the github version. We also import the `serialization` feature in case we wa
 
 ### **Item**
 
-This is the simplest storage object in this toolkit. It based on the similarly named Item from cosmwasm-storage-plus. Item allows the user to specify the type of the object being stored and the serialization/deserialization method used to store it (default being Bincode2). **One can think of the Item struct as a wrapper for the storage key.** Note that you want to use Json to serde an enum or any struct that stores an enum (except for the standard Option enum), because Bincode2 somehow uses floats during the deserialization of enums. This is why other cosmwasm chains don't use Bincode2 at all, however, you gain some performance when you can use it.
+This is the simplest storage object in this toolkit. It is based on the similarly named Item from cosmwasm-storage-plus. Item allows the user to specify the type of the object being stored and the serialization/deserialization method used to store it (default being Bincode2). **One can think of the Item struct as a wrapper for the storage key.** Note that you want to use Json to serde an enum or any struct that stores an enum (except for the standard Option enum), because Bincode2 somehow uses floats during the deserialization of enums. This is why other cosmwasm chains don't use Bincode2 at all, however, you gain some performance when you can use it.
 
 #### **Initialize**
 
@@ -54,37 +54,37 @@ pub static SOME_ENUM: Item<SomeEnum, Json> = Item::new(b"some_enum");
 
 #### **Read/Write**
 
-The way to read/write to/from strorage is to use its methods. These methods are `save`, `load`, `may_load`, `remove`, `update`. Here is an example usecase for each in execution inside `contract.rs`:
+The way to read/write to/from storage is to use its methods. These methods are `save`, `load`, `may_load`, `remove`, `update`. Here is an example use case for each in execution inside `contract.rs`:
 
 ```ignore
 // The compiler knows that owner_addr is Addr
-let owner_addr = OWNER.load(&deps.storage)?;
+let owner_addr = OWNER.load(deps.storage)?;
 ```
 
 ```ignore
-OWNER.save(&mut deps.storage, &env.message.sender)?;
-```
-
-```ignore
-// The compiler knows that may_addr is Option<Addr>
-let may_addr = OWNER.may_load(&deps.storage)?;
+OWNER.save(deps.storage, &info.sender)?;
 ```
 
 ```ignore
 // The compiler knows that may_addr is Option<Addr>
-let may_addr = OWNER.remove(&mut deps.storage)?;
+let may_addr = OWNER.may_load(deps.storage)?;
 ```
 
 ```ignore
 // The compiler knows that may_addr is Option<Addr>
-let may_addr = OWNER.update(&mut deps.storage, |_x| Ok(env.message.sender))?;
+let may_addr = OWNER.remove(deps.storage)?;
+```
+
+```ignore
+// The compiler knows that may_addr is Option<Addr>
+let may_addr = OWNER.update(deps.storage, |_x| Ok(info.sender))?;
 ```
 
 ### **AppendStore**
 
-AppendStore is meant replicate the functionality of an append list in a cosmwasm efficient manner. The length of the list is stored and used to pop/push items to the list. It also has a method to create a read only iterator.
+AppendStore is meant to replicate the functionality of an append list in a cosmwasm efficient manner. The length of the list is stored and used to pop/push items to the list. It also has a method to create a read only iterator.
 
-This storage object also has the method `remove` to remove a stored object from an arbitrary position in the list, but this can be exteremely inefficient.
+This storage object also has the method `remove` to remove a stored object from an arbitrary position in the list, but this can be extremely inefficient.
 
 > ❗ Removing a storage object further from the tail gets increasingly inefficient. We recommend you use `pop` and `push` whenever possible.
 
@@ -95,7 +95,7 @@ The same conventions from `Item` also apply here, that is:
 
 #### **Initialize**
 
-To import and intialize this storage object as a static constant in `state.rs`, do the following:
+To import and initialize this storage object as a static constant in `state.rs`, do the following:
 
 ```ignore
 use secret_toolkit::storage::{AppendStore}
@@ -111,7 +111,7 @@ Often times we need these storage objects to be associated to a user address or 
 
 ```ignore
 // The compiler knows that user_count_store is AppendStore<i32, Bincode2>
-let user_count_store = COUNT_STORE.add_suffix(env.message.sender.to_string().as_bytes());
+let user_count_store = COUNT_STORE.add_suffix(info.sender.to_string().as_bytes());
 ```
 
 Sometimes when iterating these objects, we may want to load the next `n` objects at once. This may be prefered if the objects we are iterating over are cheap to store or if we know that multiple objects will need to be accessed back to back. In such cases we may want to change the internal indexing size (default of 1). We do this in `state.rs`:
@@ -147,7 +147,7 @@ This is a storage wrapper based on AppendStore that replicates a double ended li
 
 #### **Init**
 
-To import and intialize this storage object as a static constant in `state.rs`, do the following:
+To import and initialize this storage object as a static constant in `state.rs`, do the following:
 
 ```ignore
 use secret_toolkit::storage::{DequeStore}
@@ -178,7 +178,7 @@ be returned in each page.
 
 #### **Init**
 
-To import and intialize this storage object as a static constant in `state.rs`, do the following:
+To import and initialize this storage object as a static constant in `state.rs`, do the following:
 
 ```ignore
 use secret_toolkit::storage::{Keymap, KeymapBuilder}
@@ -191,22 +191,22 @@ pub static BET_STORE: Keymap<u32, BetInfo> = Keymap::new(b"bet");
 
 > ❗ Initializing the object as const instead of static will also work but be less efficient since the variable won't be able to cache length data.
 
-You can use Json serde algorithm by changing the signature to `Keymap<Addr, Uint128, Json>`, similar to all the other storage objects above. However, keep in mind that the Serde algorthm is used to serde both the stored object (`Uint128`) AND the key (`Addr`).
+You can use Json serde algorithm by changing the signature to `Keymap<Addr, Uint128, Json>`, similar to all the other storage objects above. However, keep in mind that the Serde algorithm is used to serde both the stored object (`Uint128`) AND the key (`Addr`).
 
 If you need to associate a keymap to a user address (or any other variable), then you can also do this using the `.add_suffix` method.
 
-For example suppose that in your contract, a user can make multiple bets. Then, you'd want a Keymap to be associated to each user. You would achieve this my doing the following during execution in `contract.rs`.
+For example, suppose that in your contract, a user can make multiple bets. Then, you'd want a Keymap to be associated to each user. You would achieve this by doing the following during execution in `contract.rs`.
 
 ```ignore
 // The compiler knows that user_bet_store is AppendStore<u32, BetInfo>
-let user_count_store = BET_STORE.add_suffix(env.message.sender.to_string().as_bytes());
+let user_count_store = BET_STORE.add_suffix(info.sender.to_string().as_bytes());
 ```
 
 #### **Advanced Init**
 
-It is also possible to modify some of the configuration settings of the Keymap structure so that it suits better to a specific usecase. In this case, we use a struct called `KeymapBuilder` to build a keymap with specialized config. Currently, we can use KeymapBuilder to modify two attributes of keymaps.
+It is also possible to modify some of the configuration settings of the Keymap structure so that it suits better to a specific use case. In this case, we use a struct called `KeymapBuilder` to build a keymap with specialized config. Currently, we can use KeymapBuilder to modify two attributes of keymaps.
 
-One is to be able disable the iterator feature altogether using `.without_iter()`. This basically turns a keymap into a typed PrefixedStorage, but it also saves a ton of gas by not storing the keys and the length of the keymap.
+One is to disable the iterator feature altogether using `.without_iter()`. This basically turns a keymap into a typed PrefixedStorage, but it also saves a ton of gas by not storing the keys and the length of the keymap.
 
 The other feature is to modify the page size of the internal indexer (only if the iterator feature is enabled, i.e. this setting is irrelevant if `.without_iter()` is used). Keymap iterates by using internal index pages allowing it to load the next 5 objects at the same time. You can change the default 5 to any `u32` greater than zero by using `.with_page_size(num)`. This allows the user to optimize the gas usage of Keymap.
 
@@ -236,19 +236,19 @@ You can find more examples of using keymaps in the unit tests of Keymap in `keym
 To insert, remove, read from the keymap, do the following:
 
 ```ignore
-let user_addr: Addr = env.message.sender;
+let user_addr: Addr = info.sender;
 
 let foo = Foo {
     message: "string one".to_string(),
     votes: 1111,
 };
 
-ADDR_VOTE.insert(&mut deps.storage, &user_addr, &foo)?;
+ADDR_VOTE.insert(deps.storage, &user_addr, &foo)?;
 // Compiler knows that this is Foo
-let read_foo = ADDR_VOTE.get(&deps.storage, &user_addr).unwrap();
+let read_foo = ADDR_VOTE.get(deps.storage, &user_addr).unwrap();
 assert_eq!(read_foo, foo1);
-ADDR_VOTE.remove(&mut deps.storage, &user_addr)?;
-assert_eq!(ADDR_VOTE.get_len(&deps.storage)?, 0);
+ADDR_VOTE.remove(deps.storage, &user_addr)?;
+assert_eq!(ADDR_VOTE.get_len(deps.storage)?, 0);
 ```
 
 #### **Iterator**
@@ -327,7 +327,7 @@ An example use-case for such a structure is if you have a set of whitelisted use
 
 #### **Init**
 
-To import and intialize this storage object as a static constant in `state.rs`, do the following:
+To import and initialize this storage object as a static constant in `state.rs`, do the following:
 
 ```ignore
 use secret_toolkit::storage::{Keyset, KeysetBuilder}

--- a/packages/storage/Readme.md
+++ b/packages/storage/Readme.md
@@ -213,10 +213,10 @@ The other feature is to modify the page size of the internal indexer (only if th
 The following is used to produce a Keymap without an iterator in `state.rs`
 
 ```ignore
-pub static JSON_ADDR_VOTE: Keymap<String, Foo, Json, _> =
+pub static JSON_ADDR_VOTE: Keymap<String, Foo, Json, WithoutIter> =
             KeymapBuilder::new(b"json_vote").without_iter().build();
 
-pub static BINCODE_ADDR_VOTE: Keymap<String, Foo, Bincode2, _> =
+pub static BINCODE_ADDR_VOTE: Keymap<String, Foo, Bincode2, WithoutIter> =
             KeymapBuilder::new(b"bincode_vote").without_iter().build();
 ```
 

--- a/packages/storage/src/append_store.rs
+++ b/packages/storage/src/append_store.rs
@@ -362,7 +362,7 @@ mod tests {
         let append_store: AppendStore<i32> = AppendStore::new(b"test");
 
         assert!(append_store.length.lock().unwrap().eq(&None));
-        assert_eq!(append_store.get_len(&mut storage)?, 0);
+        assert_eq!(append_store.get_len(&storage)?, 0);
         assert!(append_store.length.lock().unwrap().eq(&Some(0)));
 
         append_store.push(&mut storage, &1234)?;
@@ -370,21 +370,21 @@ mod tests {
         append_store.push(&mut storage, &3412)?;
         append_store.push(&mut storage, &4321)?;
         assert!(append_store.length.lock().unwrap().eq(&Some(4)));
-        assert_eq!(append_store.get_len(&mut storage)?, 4);
+        assert_eq!(append_store.get_len(&storage)?, 4);
 
         assert_eq!(append_store.pop(&mut storage), Ok(4321));
         assert_eq!(append_store.pop(&mut storage), Ok(3412));
         assert!(append_store.length.lock().unwrap().eq(&Some(2)));
-        assert_eq!(append_store.get_len(&mut storage)?, 2);
+        assert_eq!(append_store.get_len(&storage)?, 2);
 
         assert_eq!(append_store.pop(&mut storage), Ok(2143));
         assert_eq!(append_store.pop(&mut storage), Ok(1234));
         assert!(append_store.length.lock().unwrap().eq(&Some(0)));
-        assert_eq!(append_store.get_len(&mut storage)?, 0);
+        assert_eq!(append_store.get_len(&storage)?, 0);
 
         assert!(append_store.pop(&mut storage).is_err());
         assert!(append_store.length.lock().unwrap().eq(&Some(0)));
-        assert_eq!(append_store.get_len(&mut storage)?, 0);
+        assert_eq!(append_store.get_len(&storage)?, 0);
 
         Ok(())
     }

--- a/packages/storage/src/append_store.rs
+++ b/packages/storage/src/append_store.rs
@@ -591,9 +591,16 @@ mod tests {
 
     #[test]
     fn test_suffixed_reverse_iter() -> StdResult<()> {
+        test_suffixed_reverse_iter_with_size(1)?;
+        test_suffixed_reverse_iter_with_size(3)?;
+        test_suffixed_reverse_iter_with_size(5)?;
+        Ok(())
+    }
+
+    fn test_suffixed_reverse_iter_with_size(page_size: u32) -> StdResult<()> {
         let mut storage = MockStorage::new();
         let suffix: &[u8] = b"test_suffix";
-        let original_store: AppendStore<i32> = AppendStore::new(b"test");
+        let original_store: AppendStore<i32> = AppendStore::new_with_page_size(b"test", page_size);
         let append_store = original_store.add_suffix(suffix);
 
         append_store.push(&mut storage, &1234)?;
@@ -697,8 +704,18 @@ mod tests {
 
     #[test]
     fn test_removes() -> StdResult<()> {
+        test_removes_with_size(1)?;
+        test_removes_with_size(2)?;
+        test_removes_with_size(7)?;
+        test_removes_with_size(8)?;
+        test_removes_with_size(13)?;
+
+        Ok(())
+    }
+
+    fn test_removes_with_size(page_size: u32) -> StdResult<()> {
         let mut storage = MockStorage::new();
-        let deque_store: AppendStore<i32> = AppendStore::new(b"test");
+        let deque_store: AppendStore<i32> = AppendStore::new_with_page_size(b"test", page_size);
         deque_store.push(&mut storage, &1)?;
         deque_store.push(&mut storage, &2)?;
         deque_store.push(&mut storage, &3)?;

--- a/packages/storage/src/deque_store.rs
+++ b/packages/storage/src/deque_store.rs
@@ -721,6 +721,113 @@ mod tests {
     }
 
     #[test]
+    fn test_overwrite() -> StdResult<()> {
+        test_overwrite_with_page_size(1)?;
+        test_overwrite_with_page_size(6)?;
+        test_overwrite_with_page_size(9)?;
+        test_overwrite_with_page_size(13)?;
+        test_overwrite_with_page_size(27)?;
+
+        Ok(())
+    }
+
+    fn test_overwrite_with_page_size(size: u32) -> StdResult<()> {
+        let mut storage = MockStorage::new();
+        let deque_store: DequeStore<i32> = DequeStore::new_with_page_size(b"test", size);
+        deque_store.push_front(&mut storage, &2)?;
+        deque_store.push_back(&mut storage, &3)?;
+        deque_store.push_back(&mut storage, &4)?;
+        deque_store.push_back(&mut storage, &5)?;
+        deque_store.push_back(&mut storage, &6)?;
+        deque_store.push_front(&mut storage, &1)?;
+        deque_store.push_back(&mut storage, &7)?;
+        deque_store.push_back(&mut storage, &8)?;
+
+        assert!(deque_store.remove(&mut storage, 8).is_err());
+        assert!(deque_store.remove(&mut storage, 9).is_err());
+
+        assert_eq!(deque_store.remove(&mut storage, 7), Ok(8));
+        assert_eq!(deque_store.get_at(&storage, 6), Ok(7));
+        assert_eq!(deque_store.get_at(&storage, 5), Ok(6));
+        assert_eq!(deque_store.get_at(&storage, 4), Ok(5));
+        assert_eq!(deque_store.get_at(&storage, 3), Ok(4));
+        assert_eq!(deque_store.get_at(&storage, 2), Ok(3));
+        assert_eq!(deque_store.get_at(&storage, 1), Ok(2));
+        assert_eq!(deque_store.get_at(&storage, 0), Ok(1));
+
+        assert_eq!(deque_store.remove(&mut storage, 6), Ok(7));
+        assert_eq!(deque_store.get_at(&storage, 5), Ok(6));
+        assert_eq!(deque_store.get_at(&storage, 4), Ok(5));
+        assert_eq!(deque_store.get_at(&storage, 3), Ok(4));
+        assert_eq!(deque_store.get_at(&storage, 2), Ok(3));
+        assert_eq!(deque_store.get_at(&storage, 1), Ok(2));
+        assert_eq!(deque_store.get_at(&storage, 0), Ok(1));
+
+        assert_eq!(deque_store.remove(&mut storage, 3), Ok(4));
+        assert_eq!(deque_store.get_at(&storage, 4), Ok(6));
+        assert_eq!(deque_store.get_at(&storage, 3), Ok(5));
+        assert_eq!(deque_store.get_at(&storage, 2), Ok(3));
+        assert_eq!(deque_store.get_at(&storage, 1), Ok(2));
+        assert_eq!(deque_store.get_at(&storage, 0), Ok(1));
+        assert!(deque_store.get_at(&storage, 5).is_err());
+
+        deque_store.push_back(&mut storage, &5)?;
+        assert_eq!(deque_store.get_at(&storage, 5), Ok(5));
+        assert_eq!(deque_store.get_at(&storage, 4), Ok(6));
+        assert_eq!(deque_store.get_at(&storage, 3), Ok(5));
+        assert_eq!(deque_store.get_at(&storage, 2), Ok(3));
+        assert_eq!(deque_store.get_at(&storage, 1), Ok(2));
+        assert_eq!(deque_store.get_at(&storage, 0), Ok(1));
+
+        assert_eq!(deque_store.remove(&mut storage, 1), Ok(2));
+        assert_eq!(deque_store.get_at(&storage, 4), Ok(5));
+        assert_eq!(deque_store.get_at(&storage, 3), Ok(6));
+        assert_eq!(deque_store.get_at(&storage, 2), Ok(5));
+        assert_eq!(deque_store.get_at(&storage, 1), Ok(3));
+        assert_eq!(deque_store.get_at(&storage, 0), Ok(1));
+
+        assert_eq!(deque_store.remove(&mut storage, 2), Ok(5));
+        assert_eq!(deque_store.get_at(&storage, 3), Ok(5));
+        assert_eq!(deque_store.get_at(&storage, 2), Ok(6));
+        assert_eq!(deque_store.get_at(&storage, 1), Ok(3));
+        assert_eq!(deque_store.get_at(&storage, 0), Ok(1));
+
+        assert_eq!(deque_store.remove(&mut storage, 1), Ok(3));
+        assert_eq!(deque_store.get_at(&storage, 2), Ok(5));
+        assert_eq!(deque_store.get_at(&storage, 1), Ok(6));
+        assert_eq!(deque_store.get_at(&storage, 0), Ok(1));
+
+        assert_eq!(deque_store.remove(&mut storage, 1), Ok(6));
+        assert_eq!(deque_store.get_at(&storage, 1), Ok(5));
+        assert_eq!(deque_store.get_at(&storage, 0), Ok(1));
+
+        assert_eq!(deque_store.remove(&mut storage, 0), Ok(1));
+        assert_eq!(deque_store.remove(&mut storage, 0), Ok(5));
+
+        assert!(deque_store.remove(&mut storage, 0).is_err());
+
+        deque_store.push_front(&mut storage, &2)?;
+        deque_store.push_back(&mut storage, &3)?;
+        deque_store.push_back(&mut storage, &4)?;
+        deque_store.push_back(&mut storage, &5)?;
+        deque_store.push_back(&mut storage, &6)?;
+        deque_store.push_front(&mut storage, &1)?;
+        deque_store.push_back(&mut storage, &7)?;
+        deque_store.push_back(&mut storage, &8)?;
+
+        assert_eq!(deque_store.get_at(&storage, 7), Ok(8));
+        assert_eq!(deque_store.get_at(&storage, 6), Ok(7));
+        assert_eq!(deque_store.get_at(&storage, 5), Ok(6));
+        assert_eq!(deque_store.get_at(&storage, 4), Ok(5));
+        assert_eq!(deque_store.get_at(&storage, 3), Ok(4));
+        assert_eq!(deque_store.get_at(&storage, 2), Ok(3));
+        assert_eq!(deque_store.get_at(&storage, 1), Ok(2));
+        assert_eq!(deque_store.get_at(&storage, 0), Ok(1));
+
+        Ok(())
+    }
+
+    #[test]
     fn test_iterator() -> StdResult<()> {
         let mut storage = MockStorage::new();
         let deque_store: DequeStore<i32> = DequeStore::new(b"test");

--- a/packages/storage/src/keymap.rs
+++ b/packages/storage/src/keymap.rs
@@ -12,7 +12,7 @@ use cosmwasm_storage::to_length_prefixed;
 
 use secret_toolkit_serialization::{Bincode2, Serde};
 
-use crate::iter_options::{IterOption, WithIter, WithoutIter};
+use crate::{IterOption, WithIter, WithoutIter};
 
 const INDEXES: &[u8] = b"indexes";
 const MAP_LENGTH: &[u8] = b"length";

--- a/packages/storage/src/keymap.rs
+++ b/packages/storage/src/keymap.rs
@@ -18,11 +18,11 @@ const MAP_LENGTH: &[u8] = b"length";
 const DEFAULT_PAGE_SIZE: u32 = 5;
 
 pub struct WithIter;
-pub struct WithNoIter;
+pub struct WithoutIter;
 pub trait IterOption {}
 
 impl IterOption for WithIter {}
-impl IterOption for WithNoIter {}
+impl IterOption for WithoutIter {}
 
 #[derive(Serialize, Deserialize)]
 struct InternalItem<T, Ser>
@@ -94,7 +94,7 @@ where
         }
     }
     /// Disables the iterator of the keymap, saving at least 4000 gas in each insertion.
-    pub const fn without_iter(&self) -> KeymapBuilder<'a, K, T, Ser, WithNoIter> {
+    pub const fn without_iter(&self) -> KeymapBuilder<'a, K, T, Ser, WithoutIter> {
         KeymapBuilder {
             namespace: self.namespace,
             page_size: self.page_size,
@@ -120,13 +120,13 @@ where
 }
 
 // This enables writing `append_store.iter().skip(n).rev()`
-impl<'a, K, T, Ser> KeymapBuilder<'a, K, T, Ser, WithNoIter>
+impl<'a, K, T, Ser> KeymapBuilder<'a, K, T, Ser, WithoutIter>
 where
     K: Serialize + DeserializeOwned,
     T: Serialize + DeserializeOwned,
     Ser: Serde,
 {
-    pub const fn build(&self) -> Keymap<'a, K, T, Ser, WithNoIter> {
+    pub const fn build(&self) -> Keymap<'a, K, T, Ser, WithoutIter> {
         Keymap {
             namespace: self.namespace,
             prefix: None,
@@ -196,7 +196,7 @@ impl<'a, K: Serialize + DeserializeOwned, T: Serialize + DeserializeOwned, Ser: 
 }
 
 impl<'a, K: Serialize + DeserializeOwned, T: Serialize + DeserializeOwned, Ser: Serde>
-    Keymap<'a, K, T, Ser, WithNoIter>
+    Keymap<'a, K, T, Ser, WithoutIter>
 {
     /// Serialize key
     fn serialize_key(&self, key: &K) -> StdResult<Vec<u8>> {
@@ -574,7 +574,7 @@ impl<'a, K: Serialize + DeserializeOwned, T: Serialize + DeserializeOwned, Ser: 
 }
 
 impl<'a, K: Serialize + DeserializeOwned, T: Serialize + DeserializeOwned, Ser: Serde>
-    PrefixedTypedStorage<T, Ser> for Keymap<'a, K, T, Ser, WithNoIter>
+    PrefixedTypedStorage<T, Ser> for Keymap<'a, K, T, Ser, WithoutIter>
 {
     fn as_slice(&self) -> &[u8] {
         if let Some(prefix) = &self.prefix {

--- a/packages/storage/src/keymap.rs
+++ b/packages/storage/src/keymap.rs
@@ -12,7 +12,7 @@ use cosmwasm_storage::to_length_prefixed;
 
 use secret_toolkit_serialization::{Bincode2, Serde};
 
-pub use crate::{IterOption, WithIter, WithoutIter};
+pub use super::{IterOption, WithIter, WithoutIter};
 
 const INDEXES: &[u8] = b"indexes";
 const MAP_LENGTH: &[u8] = b"length";

--- a/packages/storage/src/keymap.rs
+++ b/packages/storage/src/keymap.rs
@@ -12,7 +12,7 @@ use cosmwasm_storage::to_length_prefixed;
 
 use secret_toolkit_serialization::{Bincode2, Serde};
 
-pub use super::{IterOption, WithIter, WithoutIter};
+use crate::iter_options::{IterOption, WithIter, WithoutIter};
 
 const INDEXES: &[u8] = b"indexes";
 const MAP_LENGTH: &[u8] = b"length";

--- a/packages/storage/src/keymap.rs
+++ b/packages/storage/src/keymap.rs
@@ -1254,7 +1254,7 @@ mod tests {
         keymap.insert(&mut storage, &b"key1".to_vec(), &foo1)?;
         let contains_k1 = keymap.contains(&storage, &b"key1".to_vec());
 
-        assert_eq!(contains_k1, true);
+        assert!(contains_k1);
 
         Ok(())
     }

--- a/packages/storage/src/keymap.rs
+++ b/packages/storage/src/keymap.rs
@@ -12,17 +12,12 @@ use cosmwasm_storage::to_length_prefixed;
 
 use secret_toolkit_serialization::{Bincode2, Serde};
 
+use crate::{IterOption, WithIter, WithoutIter};
+
 const INDEXES: &[u8] = b"indexes";
 const MAP_LENGTH: &[u8] = b"length";
 
 const DEFAULT_PAGE_SIZE: u32 = 5;
-
-pub struct WithIter;
-pub struct WithoutIter;
-pub trait IterOption {}
-
-impl IterOption for WithIter {}
-impl IterOption for WithoutIter {}
 
 #[derive(Serialize, Deserialize)]
 struct InternalItem<T, Ser>

--- a/packages/storage/src/keymap.rs
+++ b/packages/storage/src/keymap.rs
@@ -12,7 +12,7 @@ use cosmwasm_storage::to_length_prefixed;
 
 use secret_toolkit_serialization::{Bincode2, Serde};
 
-use crate::{IterOption, WithIter, WithoutIter};
+pub use crate::{IterOption, WithIter, WithoutIter};
 
 const INDEXES: &[u8] = b"indexes";
 const MAP_LENGTH: &[u8] = b"length";

--- a/packages/storage/src/keymap.rs
+++ b/packages/storage/src/keymap.rs
@@ -1146,45 +1146,6 @@ mod tests {
     }
 
     #[test]
-    fn test_keymap_reverse_iterator() -> StdResult<()> {
-        let mut storage = MockStorage::new();
-        let keymap: Keymap<i32, i32> = Keymap::new(b"test");
-        keymap.insert(&mut storage, &1234, &1234)?;
-        keymap.insert(&mut storage, &2143, &2143)?;
-        keymap.insert(&mut storage, &3412, &3412)?;
-        keymap.insert(&mut storage, &4321, &4321)?;
-
-        let mut iter = keymap.iter(&storage)?.rev();
-        assert_eq!(iter.next(), Some(Ok((4321, 4321))));
-        assert_eq!(iter.next(), Some(Ok((3412, 3412))));
-        assert_eq!(iter.next(), Some(Ok((2143, 2143))));
-        assert_eq!(iter.next(), Some(Ok((1234, 1234))));
-        assert_eq!(iter.next(), None);
-
-        // iterate twice to make sure nothing changed
-        let mut iter = keymap.iter(&storage)?.rev();
-        assert_eq!(iter.next(), Some(Ok((4321, 4321))));
-        assert_eq!(iter.next(), Some(Ok((3412, 3412))));
-        assert_eq!(iter.next(), Some(Ok((2143, 2143))));
-        assert_eq!(iter.next(), Some(Ok((1234, 1234))));
-        assert_eq!(iter.next(), None);
-
-        // make sure our implementation of `nth_back` doesn't break anything
-        let mut iter = keymap.iter(&storage)?.rev().skip(2);
-        assert_eq!(iter.next(), Some(Ok((2143, 2143))));
-        assert_eq!(iter.next(), Some(Ok((1234, 1234))));
-        assert_eq!(iter.next(), None);
-
-        // make sure our implementation of `ExactSizeIterator` works well
-        let mut iter = keymap.iter(&storage)?.skip(2).rev();
-        assert_eq!(iter.next(), Some(Ok((4321, 4321))));
-        assert_eq!(iter.next(), Some(Ok((3412, 3412))));
-        assert_eq!(iter.next(), None);
-
-        Ok(())
-    }
-
-    #[test]
     fn test_keymap_iter_keys() -> StdResult<()> {
         let mut storage = MockStorage::new();
 
@@ -1457,9 +1418,19 @@ mod tests {
     }
 
     #[test]
-    fn test_keymap_custom_page_reverse_iterator() -> StdResult<()> {
+    fn test_keymap_reverse_iter() -> StdResult<()> {
+        test_keymap_custom_page_reverse_iterator(1)?;
+        test_keymap_custom_page_reverse_iterator(2)?;
+        test_keymap_custom_page_reverse_iterator(5)?;
+        test_keymap_custom_page_reverse_iterator(25)?;
+        Ok(())
+    }
+
+    fn test_keymap_custom_page_reverse_iterator(page_size: u32) -> StdResult<()> {
         let mut storage = MockStorage::new();
-        let keymap: Keymap<i32, i32> = KeymapBuilder::new(b"test").with_page_size(1).build();
+        let keymap: Keymap<i32, i32> = KeymapBuilder::new(b"test")
+            .with_page_size(page_size)
+            .build();
         keymap.insert(&mut storage, &1234, &1234)?;
         keymap.insert(&mut storage, &2143, &2143)?;
         keymap.insert(&mut storage, &3412, &3412)?;

--- a/packages/storage/src/keyset.rs
+++ b/packages/storage/src/keyset.rs
@@ -1,0 +1,1158 @@
+use std::convert::TryInto;
+use std::marker::PhantomData;
+use std::sync::Mutex;
+
+use serde::{de::DeserializeOwned, Serialize};
+
+use cosmwasm_std::{StdError, StdResult, Storage};
+use cosmwasm_storage::to_length_prefixed;
+
+use secret_toolkit_serialization::{Bincode2, Serde};
+
+const INDEXES: &[u8] = b"indexes";
+const MAP_LENGTH: &[u8] = b"length";
+
+const DEFAULT_PAGE_SIZE: u32 = 5;
+
+pub struct WithIter;
+pub struct WithNoIter;
+pub trait IterOption {}
+
+impl IterOption for WithIter {}
+impl IterOption for WithNoIter {}
+
+pub struct KeysetBuilder<'a, K, Ser = Bincode2, I = WithIter> {
+    /// prefix of the newly constructed Storage
+    namespace: &'a [u8],
+    page_size: u32,
+    key_type: PhantomData<K>,
+    serialization_type: PhantomData<Ser>,
+    iter_option: PhantomData<I>,
+}
+
+impl<'a, K, Ser> KeysetBuilder<'a, K, Ser, WithIter>
+where
+    K: Serialize + DeserializeOwned,
+    Ser: Serde,
+{
+    /// Creates a KeysetBuilder with default features
+    pub const fn new(namespace: &'a [u8]) -> Self {
+        Self {
+            namespace,
+            page_size: DEFAULT_PAGE_SIZE,
+            key_type: PhantomData,
+            serialization_type: PhantomData,
+            iter_option: PhantomData,
+        }
+    }
+    /// Modifies the number of values stored in one page of indexing, for the iterator
+    pub const fn with_page_size(&self, indexes_size: u32) -> Self {
+        if indexes_size == 0 {
+            panic!("Zero index page size used in keyset")
+        }
+        Self {
+            namespace: self.namespace,
+            page_size: indexes_size,
+            key_type: self.key_type,
+            serialization_type: self.serialization_type,
+            iter_option: self.iter_option,
+        }
+    }
+    /// Disables the iterator of the keyset, saving at least 4000 gas in each insertion.
+    pub const fn without_iter(&self) -> KeysetBuilder<'a, K, Ser, WithNoIter> {
+        KeysetBuilder {
+            namespace: self.namespace,
+            page_size: self.page_size,
+            key_type: PhantomData,
+            serialization_type: PhantomData,
+            iter_option: PhantomData,
+        }
+    }
+    /// Returns a keymap with the given configuration
+    pub const fn build(&self) -> Keyset<'a, K, Ser, WithIter> {
+        Keyset {
+            namespace: self.namespace,
+            prefix: None,
+            page_size: self.page_size,
+            length: Mutex::new(None),
+            key_type: self.key_type,
+            iter_option: self.iter_option,
+            serialization_type: self.serialization_type,
+        }
+    }
+}
+
+// This enables writing `append_store.iter().skip(n).rev()`
+impl<'a, K, Ser> KeysetBuilder<'a, K, Ser, WithNoIter>
+where
+    K: Serialize + DeserializeOwned,
+    Ser: Serde,
+{
+    pub const fn build(&self) -> Keyset<'a, K, Ser, WithNoIter> {
+        Keyset {
+            namespace: self.namespace,
+            prefix: None,
+            page_size: self.page_size,
+            length: Mutex::new(None),
+            key_type: self.key_type,
+            iter_option: self.iter_option,
+            serialization_type: self.serialization_type,
+        }
+    }
+}
+
+pub struct Keyset<'a, K, Ser = Bincode2, I = WithIter>
+where
+    K: Serialize + DeserializeOwned,
+    Ser: Serde,
+    I: IterOption,
+{
+    /// prefix of the newly constructed Storage
+    namespace: &'a [u8],
+    /// needed if any suffixes were added to the original namespace.
+    prefix: Option<Vec<u8>>,
+    page_size: u32,
+    length: Mutex<Option<u32>>,
+    key_type: PhantomData<K>,
+    iter_option: PhantomData<I>,
+    serialization_type: PhantomData<Ser>,
+}
+
+impl<'a, K: Serialize + DeserializeOwned, Ser: Serde> Keyset<'a, K, Ser> {
+    /// constructor
+    pub const fn new(prefix: &'a [u8]) -> Self {
+        Self {
+            namespace: prefix,
+            prefix: None,
+            page_size: DEFAULT_PAGE_SIZE,
+            length: Mutex::new(None),
+            key_type: PhantomData,
+            serialization_type: PhantomData,
+            iter_option: PhantomData,
+        }
+    }
+
+    /// This is used to produce a new Keyset. This can be used when you want to associate an Keyset to each user
+    /// and you still get to define the Keyset as a static constant
+    pub fn add_suffix(&self, suffix: &[u8]) -> Self {
+        let suffix = to_length_prefixed(suffix);
+        let prefix = self.prefix.as_deref().unwrap_or(self.namespace);
+        let prefix = [prefix, suffix.as_slice()].concat();
+        Self {
+            namespace: self.namespace,
+            prefix: Some(prefix),
+            page_size: self.page_size,
+            length: Mutex::new(None),
+            key_type: self.key_type,
+            serialization_type: self.serialization_type,
+            iter_option: self.iter_option,
+        }
+    }
+}
+
+impl<'a, K: Serialize + DeserializeOwned, Ser: Serde> Keyset<'a, K, Ser, WithNoIter> {
+    fn as_slice(&self) -> &[u8] {
+        if let Some(prefix) = &self.prefix {
+            prefix
+        } else {
+            self.namespace
+        }
+    }
+    /// returns the actual storage key
+    fn storage_key(&self, key: &K) -> StdResult<Vec<u8>> {
+        let prefix = self.as_slice();
+        let key_vec = self.serialize_key(key)?;
+        Ok([prefix, key_vec.as_slice()].concat())
+    }
+    /// Serialize key
+    fn serialize_key(&self, key: &K) -> StdResult<Vec<u8>> {
+        Ser::serialize(key)
+    }
+
+    /// user facing remove function
+    pub fn remove(&self, storage: &mut dyn Storage, value: &K) -> StdResult<()> {
+        let key_vec = self.storage_key(value)?;
+        storage.remove(&key_vec);
+        Ok(())
+    }
+
+    /// user facing insert function
+    pub fn insert(&self, storage: &mut dyn Storage, value: &K) -> StdResult<()> {
+        let key_vec = self.storage_key(value)?;
+        storage.set(&key_vec, &[0]);
+        Ok(())
+    }
+
+    /// user facing method that checks if this value is stored.
+    pub fn contains(&self, storage: &dyn Storage, value: &K) -> bool {
+        match self.storage_key(value) {
+            Ok(key_vec) => storage.get(&key_vec).is_some(),
+            Err(_) => false,
+        }
+    }
+}
+
+impl<'a, K: Serialize + DeserializeOwned, Ser: Serde> Keyset<'a, K, Ser, WithIter> {
+    fn as_slice(&self) -> &[u8] {
+        if let Some(prefix) = &self.prefix {
+            prefix
+        } else {
+            self.namespace
+        }
+    }
+    /// returns the actual storage key
+    fn storage_key(&self, key: &K) -> StdResult<Vec<u8>> {
+        let prefix = self.as_slice();
+        let key_vec = self.serialize_key(key)?;
+        Ok([prefix, key_vec.as_slice()].concat())
+    }
+    /// Serialize key
+    fn serialize_key(&self, key: &K) -> StdResult<Vec<u8>> {
+        Ser::serialize(key)
+    }
+
+    /// Deserialize key
+    fn deserialize_key(&self, key_data: &[u8]) -> StdResult<K> {
+        Ser::deserialize(key_data)
+    }
+
+    fn _page_from_position(&self, position: u32) -> u32 {
+        position / self.page_size
+    }
+
+    /// get total number of objects saved
+    pub fn get_len(&self, storage: &dyn Storage) -> StdResult<u32> {
+        let mut may_len = self.length.lock().unwrap();
+        match *may_len {
+            Some(length) => Ok(length),
+            None => {
+                let len_key = [self.as_slice(), MAP_LENGTH].concat();
+                if let Some(len_vec) = storage.get(&len_key) {
+                    let len_bytes = len_vec
+                        .as_slice()
+                        .try_into()
+                        .map_err(|err| StdError::parse_err("u32", err))?;
+                    let len = u32::from_be_bytes(len_bytes);
+                    *may_len = Some(len);
+                    Ok(len)
+                } else {
+                    *may_len = Some(0);
+                    Ok(0)
+                }
+            }
+        }
+    }
+
+    /// checks if the collection has any elements
+    pub fn is_empty(&self, storage: &dyn Storage) -> StdResult<bool> {
+        Ok(self.get_len(storage)? == 0)
+    }
+
+    /// set length of the map
+    fn set_len(&self, storage: &mut dyn Storage, len: u32) -> StdResult<()> {
+        let len_key = [self.as_slice(), MAP_LENGTH].concat();
+        storage.set(&len_key, &len.to_be_bytes());
+
+        let mut may_len = self.length.lock().unwrap();
+        *may_len = Some(len);
+
+        Ok(())
+    }
+
+    /// Used to get the indexes stored in the given page number
+    fn _get_indexes(&self, storage: &dyn Storage, page: u32) -> StdResult<Vec<Vec<u8>>> {
+        let indexes_key = [self.as_slice(), INDEXES, page.to_be_bytes().as_slice()].concat();
+        let maybe_serialized = storage.get(&indexes_key);
+        match maybe_serialized {
+            Some(serialized) => Bincode2::deserialize(&serialized),
+            None => Ok(vec![]),
+        }
+    }
+
+    /// Set an indexes page
+    fn _set_indexes_page(
+        &self,
+        storage: &mut dyn Storage,
+        page: u32,
+        indexes: &Vec<Vec<u8>>,
+    ) -> StdResult<()> {
+        let indexes_key = [self.as_slice(), INDEXES, page.to_be_bytes().as_slice()].concat();
+        storage.set(&indexes_key, &Bincode2::serialize(indexes)?);
+        Ok(())
+    }
+
+    /// internal item get function
+    fn _get_pos(&self, storage: &dyn Storage, key_vec: &[u8]) -> StdResult<u32> {
+        match storage.get(key_vec) {
+            Some(data) => {
+                let pos_bytes = data
+                    .as_slice()
+                    .try_into()
+                    .map_err(|err| StdError::parse_err("u32", err))?;
+                Ok(u32::from_be_bytes(pos_bytes))
+            }
+            None => Err(StdError::NotFound {
+                kind: "Keyset value not found.".to_string(),
+            }),
+        }
+    }
+
+    /// user facing remove function
+    pub fn remove(&self, storage: &mut dyn Storage, value: &K) -> StdResult<()> {
+        let prefix = self.as_slice();
+        let key_data = self.serialize_key(value)?;
+        let key_vec = [prefix, key_data.as_slice()].concat();
+
+        let removed_pos = self._get_pos(storage, &key_vec)?;
+
+        let page = self._page_from_position(removed_pos);
+
+        let mut len = self.get_len(storage)?;
+        len -= 1;
+        self.set_len(storage, len)?;
+
+        let mut indexes = self._get_indexes(storage, page)?;
+
+        let pos_in_indexes = (removed_pos % self.page_size) as usize;
+
+        if indexes[pos_in_indexes] != key_data {
+            return Err(StdError::generic_err(
+                "Tried to remove, but hash not found - should never happen",
+            ));
+        }
+
+        // if our object is the last item, then just remove it
+        if len == 0 || len == removed_pos {
+            indexes.pop();
+            self._set_indexes_page(storage, page, &indexes)?;
+            return Ok(());
+        }
+
+        // max page should use previous_len - 1 which is exactly the current len
+        let max_page = self._page_from_position(len);
+        if max_page == page {
+            // last page indexes is the same as indexes
+            let last_data = indexes.pop().ok_or_else(|| {
+                StdError::generic_err("Last item's key not found - should never happen")
+            })?;
+            let last_key = [prefix, last_data.as_slice()].concat();
+            // modify last item
+            storage.set(&last_key, &removed_pos.to_be_bytes());
+            // save to indexes
+            indexes[pos_in_indexes] = last_data;
+            self._set_indexes_page(storage, page, &indexes)?;
+        } else {
+            let mut last_page_indexes = self._get_indexes(storage, max_page)?;
+            let last_data = last_page_indexes.pop().ok_or_else(|| {
+                StdError::generic_err("Last item's key not found - should never happen")
+            })?;
+            let last_key = [prefix, last_data.as_slice()].concat();
+            // modify last item
+            storage.set(&last_key, &removed_pos.to_be_bytes());
+            // save indexes
+            indexes[pos_in_indexes] = last_data;
+            self._set_indexes_page(storage, page, &indexes)?;
+            self._set_indexes_page(storage, max_page, &last_page_indexes)?;
+        }
+
+        storage.remove(&key_vec);
+
+        Ok(())
+    }
+
+    /// user facing insert function
+    ///
+    /// returns `Ok(true)` if the set did not previously contain the value
+    /// returns `Ok(false)` if the set already contained this value
+    /// returns `Err` if the insertion fails due to an error
+    pub fn insert(&self, storage: &mut dyn Storage, value: &K) -> StdResult<bool> {
+        let prefix = self.as_slice();
+        let key_data = self.serialize_key(value)?;
+        let key_vec = [prefix, key_data.as_slice()].concat();
+
+        match storage.get(&key_vec) {
+            Some(_) => Ok(false),
+            None => {
+                // not already saved
+                let pos = self.get_len(storage)?;
+                self.set_len(storage, pos + 1)?;
+                let page = self._page_from_position(pos);
+                // save the item
+                storage.set(&key_vec, &pos.to_be_bytes());
+                // add index
+                let mut indexes = self._get_indexes(storage, page)?;
+                indexes.push(key_data);
+                self._set_indexes_page(storage, page, &indexes)?;
+                Ok(true)
+            }
+        }
+    }
+
+    /// user facing method that checks if this value is stored.
+    pub fn contains(&self, storage: &dyn Storage, value: &K) -> bool {
+        match self.storage_key(value) {
+            Ok(key_vec) => storage.get(&key_vec).is_some(),
+            Err(_) => false,
+        }
+    }
+
+    /// paginates only the values.
+    pub fn paging(&self, storage: &dyn Storage, start_page: u32, size: u32) -> StdResult<Vec<K>> {
+        let start_pos = start_page * size;
+        let mut end_pos = start_pos + size - 1;
+
+        let max_size = self.get_len(storage)?;
+
+        if max_size == 0 {
+            return Ok(vec![]);
+        }
+
+        if start_pos > max_size {
+            return Err(StdError::NotFound {
+                kind: "Out of bounds".to_string(),
+            });
+        } else if end_pos > max_size {
+            end_pos = max_size - 1;
+        }
+        self.get_keys_at_positions(storage, start_pos, end_pos)
+    }
+
+    /// tries to list keys without checking start/end bounds
+    fn get_keys_at_positions(
+        &self,
+        storage: &dyn Storage,
+        start: u32,
+        end: u32,
+    ) -> StdResult<Vec<K>> {
+        let start_page = self._page_from_position(start);
+        let end_page = self._page_from_position(end);
+
+        let mut res = vec![];
+
+        for page in start_page..=end_page {
+            let indexes = self._get_indexes(storage, page)?;
+            let start_page_pos = if page == start_page {
+                start % self.page_size
+            } else {
+                0
+            };
+            let end_page_pos = if page == end_page {
+                end % self.page_size
+            } else {
+                self.page_size - 1
+            };
+            for i in start_page_pos..=end_page_pos {
+                let key_vec = &indexes[i as usize];
+                let key = self.deserialize_key(key_vec)?;
+                res.push(key);
+            }
+        }
+        Ok(res)
+    }
+
+    /// gets a key from a specific position in indexes
+    fn get_key_from_pos(&self, storage: &dyn Storage, pos: u32) -> StdResult<K> {
+        let page = self._page_from_position(pos);
+        let indexes = self._get_indexes(storage, page)?;
+        let index = pos % self.page_size;
+        let key_vec = &indexes[index as usize];
+        self.deserialize_key(key_vec)
+    }
+
+    /// Returns a readonly iterator only for values.
+    pub fn iter(&self, storage: &'a dyn Storage) -> StdResult<ValueIter<K, Ser>> {
+        let len = self.get_len(storage)?;
+        let iter = ValueIter::new(self, storage, 0, len);
+        Ok(iter)
+    }
+}
+
+/// An iterator over the keys of the Keyset.
+pub struct ValueIter<'a, K, Ser>
+where
+    K: Serialize + DeserializeOwned,
+    Ser: Serde,
+{
+    keyset: &'a Keyset<'a, K, Ser>,
+    storage: &'a dyn Storage,
+    start: u32,
+    end: u32,
+    saved_indexes: Option<Vec<Vec<u8>>>,
+    saved_index_page: Option<u32>,
+    saved_back_indexes: Option<Vec<Vec<u8>>>,
+    saved_back_index_page: Option<u32>,
+}
+
+impl<'a, K, Ser> ValueIter<'a, K, Ser>
+where
+    K: Serialize + DeserializeOwned,
+    Ser: Serde,
+{
+    /// constructor
+    pub fn new(
+        keyset: &'a Keyset<'a, K, Ser>,
+        storage: &'a dyn Storage,
+        start: u32,
+        end: u32,
+    ) -> Self {
+        Self {
+            keyset,
+            storage,
+            start,
+            end,
+            saved_indexes: None,
+            saved_index_page: None,
+            saved_back_indexes: None,
+            saved_back_index_page: None,
+        }
+    }
+}
+
+impl<'a, K, Ser> Iterator for ValueIter<'a, K, Ser>
+where
+    K: Serialize + DeserializeOwned,
+    Ser: Serde,
+{
+    type Item = StdResult<K>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.start >= self.end {
+            return None;
+        }
+        let res: Option<Self::Item>;
+        if let (Some(page), Some(indexes)) = (&self.saved_index_page, &self.saved_indexes) {
+            let current_page = self.keyset._page_from_position(self.start);
+            if *page == current_page {
+                let current_idx = (self.start % self.keyset.page_size) as usize;
+                if current_idx + 1 > indexes.len() {
+                    res = None;
+                } else {
+                    let key_vec = &indexes[current_idx];
+                    match self.keyset.deserialize_key(key_vec) {
+                        Ok(key) => {
+                            res = Some(Ok(key));
+                        }
+                        Err(e) => {
+                            res = Some(Err(e));
+                        }
+                    }
+                }
+            } else {
+                match self.keyset._get_indexes(self.storage, current_page) {
+                    Ok(new_indexes) => {
+                        let current_idx = (self.start % self.keyset.page_size) as usize;
+                        if current_idx + 1 > new_indexes.len() {
+                            res = None;
+                        } else {
+                            let key_vec = &new_indexes[current_idx];
+                            match self.keyset.deserialize_key(key_vec) {
+                                Ok(key) => {
+                                    res = Some(Ok(key));
+                                }
+                                Err(e) => {
+                                    res = Some(Err(e));
+                                }
+                            }
+                        }
+                        self.saved_index_page = Some(current_page);
+                        self.saved_indexes = Some(new_indexes);
+                    }
+                    Err(_) => match self.keyset.get_key_from_pos(self.storage, self.start) {
+                        Ok(key) => {
+                            res = Some(Ok(key));
+                        }
+                        Err(_) => {
+                            res = None;
+                        }
+                    },
+                }
+            }
+        } else {
+            let next_page = self.keyset._page_from_position(self.start + 1);
+            let current_page = self.keyset._page_from_position(self.start);
+            match self.keyset._get_indexes(self.storage, next_page) {
+                Ok(next_index) => {
+                    if current_page == next_page {
+                        let current_idx = (self.start % self.keyset.page_size) as usize;
+                        if current_idx + 1 > next_index.len() {
+                            res = None;
+                        } else {
+                            let key_vec = &next_index[current_idx];
+                            match self.keyset.deserialize_key(key_vec) {
+                                Ok(key) => {
+                                    res = Some(Ok(key));
+                                }
+                                Err(e) => {
+                                    res = Some(Err(e));
+                                }
+                            }
+                        }
+                    } else {
+                        match self.keyset.get_key_from_pos(self.storage, self.start) {
+                            Ok(key) => {
+                                res = Some(Ok(key));
+                            }
+                            Err(_) => {
+                                res = None;
+                            }
+                        }
+                    }
+                    self.saved_index_page = Some(next_page);
+                    self.saved_indexes = Some(next_index);
+                }
+                Err(_) => match self.keyset.get_key_from_pos(self.storage, self.start) {
+                    Ok(key) => {
+                        res = Some(Ok(key));
+                    }
+                    Err(_) => {
+                        res = None;
+                    }
+                },
+            }
+        }
+        self.start += 1;
+        res
+    }
+
+    // This needs to be implemented correctly for `ExactSizeIterator` to work.
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = (self.end - self.start) as usize;
+        (len, Some(len))
+    }
+
+    // I implement `nth` manually because it is used in the standard library whenever
+    // it wants to skip over elements, but the default implementation repeatedly calls next.
+    // because that is very expensive in this case, and the items are just discarded, we wan
+    // do better here.
+    // In practice, this enables cheap paging over the storage by calling:
+    // `append_store.iter().skip(start).take(length).collect()`
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.start = self.start.saturating_add(n as u32);
+        self.next()
+    }
+}
+
+impl<'a, K, Ser> DoubleEndedIterator for ValueIter<'a, K, Ser>
+where
+    K: Serialize + DeserializeOwned,
+    Ser: Serde,
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.start >= self.end {
+            return None;
+        }
+        self.end -= 1;
+        let res;
+        if let (Some(page), Some(indexes)) = (&self.saved_back_index_page, &self.saved_back_indexes)
+        {
+            let current_page = self.keyset._page_from_position(self.end);
+            if *page == current_page {
+                let current_idx = (self.end % self.keyset.page_size) as usize;
+                if current_idx + 1 > indexes.len() {
+                    res = None;
+                } else {
+                    let key_vec = &indexes[current_idx];
+                    match self.keyset.deserialize_key(key_vec) {
+                        Ok(key) => {
+                            res = Some(Ok(key));
+                        }
+                        Err(e) => {
+                            res = Some(Err(e));
+                        }
+                    }
+                }
+            } else {
+                match self.keyset._get_indexes(self.storage, current_page) {
+                    Ok(new_indexes) => {
+                        let current_idx = (self.end % self.keyset.page_size) as usize;
+                        if current_idx + 1 > new_indexes.len() {
+                            res = None;
+                        } else {
+                            let key_vec = &new_indexes[current_idx];
+                            match self.keyset.deserialize_key(key_vec) {
+                                Ok(key) => {
+                                    res = Some(Ok(key));
+                                }
+                                Err(e) => {
+                                    res = Some(Err(e));
+                                }
+                            }
+                        }
+                        self.saved_back_index_page = Some(current_page);
+                        self.saved_back_indexes = Some(new_indexes);
+                    }
+                    Err(_) => match self.keyset.get_key_from_pos(self.storage, self.end) {
+                        Ok(key) => {
+                            res = Some(Ok(key));
+                        }
+                        Err(_) => {
+                            res = None;
+                        }
+                    },
+                }
+            }
+        } else {
+            let next_page = self.keyset._page_from_position(self.end - 1);
+            let current_page = self.keyset._page_from_position(self.end);
+            match self.keyset._get_indexes(self.storage, next_page) {
+                Ok(next_index) => {
+                    if current_page == next_page {
+                        let current_idx = (self.end % self.keyset.page_size) as usize;
+                        if current_idx + 1 > next_index.len() {
+                            res = None;
+                        } else {
+                            let key_vec = &next_index[current_idx];
+                            match self.keyset.deserialize_key(key_vec) {
+                                Ok(key) => {
+                                    res = Some(Ok(key));
+                                }
+                                Err(e) => {
+                                    res = Some(Err(e));
+                                }
+                            }
+                        }
+                    } else {
+                        match self.keyset.get_key_from_pos(self.storage, self.end) {
+                            Ok(key) => {
+                                res = Some(Ok(key));
+                            }
+                            Err(_) => {
+                                res = None;
+                            }
+                        }
+                    }
+                    self.saved_back_index_page = Some(next_page);
+                    self.saved_back_indexes = Some(next_index);
+                }
+                Err(_) => match self.keyset.get_key_from_pos(self.storage, self.end) {
+                    Ok(key) => {
+                        res = Some(Ok(key));
+                    }
+                    Err(_) => {
+                        res = None;
+                    }
+                },
+            }
+        }
+        res
+    }
+
+    // I implement `nth_back` manually because it is used in the standard library whenever
+    // it wants to skip over elements, but the default implementation repeatedly calls next_back.
+    // because that is very expensive in this case, and the items are just discarded, we wan
+    // do better here.
+    // In practice, this enables cheap paging over the storage by calling:
+    // `append_store.iter().skip(start).take(length).collect()`
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        self.end = self.end.saturating_sub(n as u32);
+        self.next_back()
+    }
+}
+
+// This enables writing `append_store.iter().skip(n).rev()`
+impl<'a, K, Ser> ExactSizeIterator for ValueIter<'a, K, Ser>
+where
+    K: Serialize + DeserializeOwned,
+    Ser: Serde,
+{
+}
+
+#[cfg(test)]
+mod tests {
+    use secret_toolkit_serialization::Json;
+    use serde::{Deserialize, Serialize};
+
+    use cosmwasm_std::testing::MockStorage;
+
+    use super::*;
+
+    #[derive(Serialize, Deserialize, Eq, PartialEq, Debug, Clone)]
+    struct Foo {
+        string: String,
+        number: i32,
+    }
+    #[test]
+    fn test_keyset_perf_insert() -> StdResult<()> {
+        let mut storage = MockStorage::new();
+
+        let total_items = 1000;
+
+        let keyset: Keyset<i32> = Keyset::new(b"test");
+
+        for i in 0..total_items {
+            keyset.insert(&mut storage, &i)?;
+        }
+
+        assert_eq!(keyset.get_len(&storage)?, 1000);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_keyset_perf_insert_remove() -> StdResult<()> {
+        let mut storage = MockStorage::new();
+
+        let total_items = 100;
+
+        let keyset: Keyset<i32> = Keyset::new(b"test");
+
+        for i in 0..total_items {
+            keyset.insert(&mut storage, &i)?;
+        }
+
+        for i in 0..total_items {
+            keyset.remove(&mut storage, &i)?;
+        }
+
+        assert_eq!(keyset.get_len(&storage)?, 0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_keyset_paging() -> StdResult<()> {
+        let mut storage = MockStorage::new();
+
+        let page_size: u32 = 5;
+        let total_items: u32 = 50;
+        let keyset: Keyset<u32> = Keyset::new(b"test");
+
+        for i in 0..total_items {
+            keyset.insert(&mut storage, &i)?;
+        }
+
+        for i in 0..((total_items / page_size) - 1) {
+            let start_page = i;
+
+            let values = keyset.paging(&storage, start_page, page_size)?;
+
+            for (index, value) in values.iter().enumerate() {
+                let i = page_size * start_page + index as u32;
+                assert_eq!(value, &i);
+            }
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_keyset_paging_overflow() -> StdResult<()> {
+        let mut storage = MockStorage::new();
+
+        let page_size = 50;
+        let total_items = 10;
+        let keyset: Keyset<u32> = Keyset::new(b"test");
+
+        for i in 0..total_items {
+            keyset.insert(&mut storage, &i)?;
+        }
+
+        let values = keyset.paging(&storage, 0, page_size)?;
+
+        assert_eq!(values.len(), total_items as usize);
+
+        for (index, value) in values.iter().enumerate() {
+            assert_eq!(value, &(index as u32))
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_keyset_insert_multiple() -> StdResult<()> {
+        let mut storage = MockStorage::new();
+
+        let keyset: Keyset<Foo> = Keyset::new(b"test");
+        let foo1 = Foo {
+            string: "string one".to_string(),
+            number: 1111,
+        };
+        let foo2 = Foo {
+            string: "string two".to_string(),
+            number: 1111,
+        };
+
+        assert!(keyset.insert(&mut storage, &foo1)?);
+        assert!(keyset.insert(&mut storage, &foo2)?);
+
+        assert!(keyset.contains(&storage, &foo1));
+        assert!(keyset.contains(&storage, &foo2));
+
+        assert!(!keyset.insert(&mut storage, &foo2)?);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_keyset_iter() -> StdResult<()> {
+        let mut storage = MockStorage::new();
+
+        let keyset: Keyset<Foo> = Keyset::new(b"test");
+        let foo1 = Foo {
+            string: "string one".to_string(),
+            number: 1111,
+        };
+        let foo2 = Foo {
+            string: "string two".to_string(),
+            number: 1111,
+        };
+
+        keyset.insert(&mut storage, &foo1)?;
+        keyset.insert(&mut storage, &foo2)?;
+
+        let mut x = keyset.iter(&storage)?;
+        let (len, _) = x.size_hint();
+        assert_eq!(len, 2);
+
+        assert_eq!(x.next().unwrap()?, foo1);
+
+        assert_eq!(x.next().unwrap()?, foo2);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_keyset_iter_keys() -> StdResult<()> {
+        let mut storage = MockStorage::new();
+
+        let keyset: Keyset<Foo> = Keyset::new(b"test");
+        let foo1 = Foo {
+            string: "string one".to_string(),
+            number: 1111,
+        };
+        let foo2 = Foo {
+            string: "string two".to_string(),
+            number: 1111,
+        };
+
+        keyset.insert(&mut storage, &foo1)?;
+        keyset.insert(&mut storage, &foo2)?;
+
+        let mut x = keyset.iter(&storage)?;
+        let (len, _) = x.size_hint();
+        assert_eq!(len, 2);
+
+        assert_eq!(x.next().unwrap()?, foo1);
+
+        assert_eq!(x.next().unwrap()?, foo2);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_keyset_suffixed_basics() -> StdResult<()> {
+        let mut storage = MockStorage::new();
+
+        let original_keyset: Keyset<Foo> = Keyset::new(b"test");
+        let keyset = original_keyset.add_suffix(b"test_suffix");
+        let foo1 = Foo {
+            string: "string one".to_string(),
+            number: 1111,
+        };
+        let foo2 = Foo {
+            string: "string two".to_string(),
+            number: 1111,
+        };
+        keyset.insert(&mut storage, &foo1)?;
+        keyset.insert(&mut storage, &foo2)?;
+
+        let read_foo1 = keyset.contains(&storage, &foo1);
+        let read_foo2 = keyset.contains(&storage, &foo2);
+
+        assert_eq!(original_keyset.get_len(&storage)?, 0);
+        assert!(read_foo1);
+        assert!(read_foo2);
+
+        let alternative_keyset: Keyset<Foo> = Keyset::new(b"alternative");
+        let alt_same_suffix = alternative_keyset.add_suffix(b"test_suffix");
+
+        assert!(alt_same_suffix.is_empty(&storage)?);
+
+        // show that it loads foo1 before removal
+        let before_remove_foo1 = keyset.contains(&storage, &foo1);
+        assert!(before_remove_foo1);
+        // and returns None after removal
+        keyset.remove(&mut storage, &foo1)?;
+        let removed_foo1 = keyset.contains(&storage, &foo1);
+        assert!(!removed_foo1);
+
+        let foo3 = Foo {
+            string: "string three".to_string(),
+            number: 1111,
+        };
+        // show what happens when reading from keys that have not been set yet.
+        assert!(!keyset.contains(&storage, &foo3));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_keyset_length() -> StdResult<()> {
+        let mut storage = MockStorage::new();
+
+        let keyset: Keyset<Foo> = Keyset::new(b"test");
+        let foo1 = Foo {
+            string: "string one".to_string(),
+            number: 1111,
+        };
+        let foo2 = Foo {
+            // same as foo1
+            string: "string one".to_string(),
+            number: 1111,
+        };
+        let foo3 = Foo {
+            string: "string three".to_string(),
+            number: 1111,
+        };
+
+        assert!(keyset.length.lock().unwrap().eq(&None));
+        assert_eq!(keyset.get_len(&storage)?, 0);
+        assert!(keyset.length.lock().unwrap().eq(&Some(0)));
+
+        keyset.insert(&mut storage, &foo1)?;
+        assert_eq!(keyset.get_len(&storage)?, 1);
+        assert!(keyset.length.lock().unwrap().eq(&Some(1)));
+
+        // add same item
+        keyset.insert(&mut storage, &foo2)?;
+        assert_eq!(keyset.get_len(&storage)?, 1);
+        assert!(keyset.length.lock().unwrap().eq(&Some(1)));
+
+        // add another item
+        keyset.insert(&mut storage, &foo3)?;
+        assert_eq!(keyset.get_len(&storage)?, 2);
+        assert!(keyset.length.lock().unwrap().eq(&Some(2)));
+
+        // remove item and check length
+        keyset.remove(&mut storage, &foo1)?;
+        assert_eq!(keyset.get_len(&storage)?, 1);
+        assert!(keyset.length.lock().unwrap().eq(&Some(1)));
+
+        // remove item and check length
+        keyset.remove(&mut storage, &foo3)?;
+        assert_eq!(keyset.get_len(&storage)?, 0);
+        assert!(keyset.length.lock().unwrap().eq(&Some(0)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_keyset_without_iter() -> StdResult<()> {
+        let mut storage = MockStorage::new();
+
+        let keyset: Keyset<Foo, Json, _> = KeysetBuilder::new(b"test").without_iter().build();
+
+        let foo1 = Foo {
+            string: "string one".to_string(),
+            number: 1111,
+        };
+        let foo2 = Foo {
+            string: "string two".to_string(),
+            number: 1111,
+        };
+        keyset.insert(&mut storage, &foo1)?;
+        keyset.insert(&mut storage, &foo2)?;
+
+        let read_foo1 = keyset.contains(&storage, &foo1);
+        let read_foo2 = keyset.contains(&storage, &foo2);
+
+        assert!(read_foo1);
+        assert!(read_foo2);
+
+        keyset.remove(&mut storage, &foo1)?;
+
+        let read_foo1 = keyset.contains(&storage, &foo1);
+        let read_foo2 = keyset.contains(&storage, &foo2);
+
+        assert!(!read_foo1);
+        assert!(read_foo2);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_keymap_custom_paging() -> StdResult<()> {
+        let mut storage = MockStorage::new();
+
+        let page_size: u32 = 5;
+        let total_items: u32 = 50;
+        let keymap: Keyset<u32> = KeysetBuilder::new(b"test").with_page_size(13).build();
+
+        for i in 0..total_items {
+            keymap.insert(&mut storage, &i)?;
+        }
+
+        for i in 0..((total_items / page_size) - 1) {
+            let start_page = i;
+
+            let values = keymap.paging(&storage, start_page, page_size)?;
+
+            for (index, value) in values.iter().enumerate() {
+                let i = page_size * start_page + index as u32;
+                assert_eq!(value, &i);
+            }
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_keymap_custom_paging_overflow() -> StdResult<()> {
+        let mut storage = MockStorage::new();
+
+        let page_size = 50;
+        let total_items = 10;
+        let keymap: Keyset<u32> = KeysetBuilder::new(b"test").with_page_size(3).build();
+
+        for i in 0..total_items {
+            keymap.insert(&mut storage, &i)?;
+        }
+
+        let values = keymap.paging(&storage, 0, page_size)?;
+
+        assert_eq!(values.len(), total_items as usize);
+
+        for (index, value) in values.iter().enumerate() {
+            assert_eq!(value, &(index as u32))
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_keymap_custom_page_iter() -> StdResult<()> {
+        let mut storage = MockStorage::new();
+
+        let keymap: Keyset<Foo> = KeysetBuilder::new(b"test").with_page_size(2).build();
+        let foo1 = Foo {
+            string: "string one".to_string(),
+            number: 1111,
+        };
+        let foo2 = Foo {
+            string: "string two".to_string(),
+            number: 1111,
+        };
+        let foo3 = Foo {
+            string: "string three".to_string(),
+            number: 1111,
+        };
+
+        keymap.insert(&mut storage, &foo1)?;
+        keymap.insert(&mut storage, &foo2)?;
+        keymap.insert(&mut storage, &foo3)?;
+
+        let mut x = keymap.iter(&storage)?;
+        let (len, _) = x.size_hint();
+        assert_eq!(len, 3);
+
+        assert_eq!(x.next().unwrap()?, foo1);
+
+        assert_eq!(x.next().unwrap()?, foo2);
+
+        assert_eq!(x.next().unwrap()?, foo3);
+
+        assert_eq!(x.next(), None);
+
+        Ok(())
+    }
+}

--- a/packages/storage/src/keyset.rs
+++ b/packages/storage/src/keyset.rs
@@ -9,7 +9,7 @@ use cosmwasm_storage::to_length_prefixed;
 
 use secret_toolkit_serialization::{Bincode2, Serde};
 
-use crate::{IterOption, WithIter, WithoutIter};
+pub use crate::{IterOption, WithIter, WithoutIter};
 
 const INDEXES: &[u8] = b"indexes";
 const MAP_LENGTH: &[u8] = b"length";

--- a/packages/storage/src/keyset.rs
+++ b/packages/storage/src/keyset.rs
@@ -15,11 +15,11 @@ const MAP_LENGTH: &[u8] = b"length";
 const DEFAULT_PAGE_SIZE: u32 = 5;
 
 pub struct WithIter;
-pub struct WithNoIter;
+pub struct WithoutIter;
 pub trait IterOption {}
 
 impl IterOption for WithIter {}
-impl IterOption for WithNoIter {}
+impl IterOption for WithoutIter {}
 
 pub struct KeysetBuilder<'a, K, Ser = Bincode2, I = WithIter> {
     /// prefix of the newly constructed Storage
@@ -59,7 +59,7 @@ where
         }
     }
     /// Disables the iterator of the keyset, saving at least 4000 gas in each insertion.
-    pub const fn without_iter(&self) -> KeysetBuilder<'a, K, Ser, WithNoIter> {
+    pub const fn without_iter(&self) -> KeysetBuilder<'a, K, Ser, WithoutIter> {
         KeysetBuilder {
             namespace: self.namespace,
             page_size: self.page_size,
@@ -83,12 +83,12 @@ where
 }
 
 // This enables writing `append_store.iter().skip(n).rev()`
-impl<'a, K, Ser> KeysetBuilder<'a, K, Ser, WithNoIter>
+impl<'a, K, Ser> KeysetBuilder<'a, K, Ser, WithoutIter>
 where
     K: Serialize + DeserializeOwned,
     Ser: Serde,
 {
-    pub const fn build(&self) -> Keyset<'a, K, Ser, WithNoIter> {
+    pub const fn build(&self) -> Keyset<'a, K, Ser, WithoutIter> {
         Keyset {
             namespace: self.namespace,
             prefix: None,
@@ -150,7 +150,7 @@ impl<'a, K: Serialize + DeserializeOwned, Ser: Serde> Keyset<'a, K, Ser> {
     }
 }
 
-impl<'a, K: Serialize + DeserializeOwned, Ser: Serde> Keyset<'a, K, Ser, WithNoIter> {
+impl<'a, K: Serialize + DeserializeOwned, Ser: Serde> Keyset<'a, K, Ser, WithoutIter> {
     fn as_slice(&self) -> &[u8] {
         if let Some(prefix) = &self.prefix {
             prefix

--- a/packages/storage/src/keyset.rs
+++ b/packages/storage/src/keyset.rs
@@ -9,7 +9,7 @@ use cosmwasm_storage::to_length_prefixed;
 
 use secret_toolkit_serialization::{Bincode2, Serde};
 
-pub use crate::{IterOption, WithIter, WithoutIter};
+pub use super::{IterOption, WithIter, WithoutIter};
 
 const INDEXES: &[u8] = b"indexes";
 const MAP_LENGTH: &[u8] = b"length";

--- a/packages/storage/src/keyset.rs
+++ b/packages/storage/src/keyset.rs
@@ -9,19 +9,17 @@ use cosmwasm_storage::to_length_prefixed;
 
 use secret_toolkit_serialization::{Bincode2, Serde};
 
-use crate::keymap::{IterOption, WithIter, WithoutIter};
-
 const INDEXES: &[u8] = b"indexes";
 const MAP_LENGTH: &[u8] = b"length";
 
 const DEFAULT_PAGE_SIZE: u32 = 5;
 
-//pub struct WithIter;
-//pub struct WithoutIter;
-//pub trait IterOption {}
+pub struct WithIter;
+pub struct WithoutIter;
+pub trait IterOption {}
 
-//impl IterOption for WithIter {}
-//impl IterOption for WithoutIter {}
+impl IterOption for WithIter {}
+impl IterOption for WithoutIter {}
 
 pub struct KeysetBuilder<'a, K, Ser = Bincode2, I = WithIter> {
     /// prefix of the newly constructed Storage

--- a/packages/storage/src/keyset.rs
+++ b/packages/storage/src/keyset.rs
@@ -9,7 +9,7 @@ use cosmwasm_storage::to_length_prefixed;
 
 use secret_toolkit_serialization::{Bincode2, Serde};
 
-pub use crate::iter_options::{IterOption, WithIter, WithoutIter};
+use crate::{IterOption, WithIter, WithoutIter};
 
 const INDEXES: &[u8] = b"indexes";
 const MAP_LENGTH: &[u8] = b"length";

--- a/packages/storage/src/keyset.rs
+++ b/packages/storage/src/keyset.rs
@@ -9,7 +9,7 @@ use cosmwasm_storage::to_length_prefixed;
 
 use secret_toolkit_serialization::{Bincode2, Serde};
 
-pub use super::{IterOption, WithIter, WithoutIter};
+pub use crate::iter_options::{IterOption, WithIter, WithoutIter};
 
 const INDEXES: &[u8] = b"indexes";
 const MAP_LENGTH: &[u8] = b"length";

--- a/packages/storage/src/keyset.rs
+++ b/packages/storage/src/keyset.rs
@@ -9,17 +9,19 @@ use cosmwasm_storage::to_length_prefixed;
 
 use secret_toolkit_serialization::{Bincode2, Serde};
 
+use crate::{IterOption, WithIter, WithoutIter};
+
 const INDEXES: &[u8] = b"indexes";
 const MAP_LENGTH: &[u8] = b"length";
 
 const DEFAULT_PAGE_SIZE: u32 = 5;
 
-pub struct WithIter;
-pub struct WithoutIter;
-pub trait IterOption {}
+//pub struct WithIter;
+//pub struct WithoutIter;
+//pub trait IterOption {}
 
-impl IterOption for WithIter {}
-impl IterOption for WithoutIter {}
+//impl IterOption for WithIter {}
+//impl IterOption for WithoutIter {}
 
 pub struct KeysetBuilder<'a, K, Ser = Bincode2, I = WithIter> {
     /// prefix of the newly constructed Storage

--- a/packages/storage/src/keyset.rs
+++ b/packages/storage/src/keyset.rs
@@ -9,17 +9,19 @@ use cosmwasm_storage::to_length_prefixed;
 
 use secret_toolkit_serialization::{Bincode2, Serde};
 
+use crate::keymap::{IterOption, WithIter, WithoutIter};
+
 const INDEXES: &[u8] = b"indexes";
 const MAP_LENGTH: &[u8] = b"length";
 
 const DEFAULT_PAGE_SIZE: u32 = 5;
 
-pub struct WithIter;
-pub struct WithoutIter;
-pub trait IterOption {}
+//pub struct WithIter;
+//pub struct WithoutIter;
+//pub trait IterOption {}
 
-impl IterOption for WithIter {}
-impl IterOption for WithoutIter {}
+//impl IterOption for WithIter {}
+//impl IterOption for WithoutIter {}
 
 pub struct KeysetBuilder<'a, K, Ser = Bincode2, I = WithIter> {
     /// prefix of the newly constructed Storage

--- a/packages/storage/src/lib.rs
+++ b/packages/storage/src/lib.rs
@@ -8,5 +8,5 @@ pub mod keyset;
 pub use append_store::AppendStore;
 pub use deque_store::DequeStore;
 pub use item::Item;
-pub use keymap::{Keymap, KeymapBuilder, WithoutIter};
+pub use keymap::{Keymap, KeymapBuilder};
 pub use keyset::{Keyset, KeysetBuilder};

--- a/packages/storage/src/lib.rs
+++ b/packages/storage/src/lib.rs
@@ -8,5 +8,5 @@ pub mod keyset;
 pub use append_store::AppendStore;
 pub use deque_store::DequeStore;
 pub use item::Item;
-pub use keymap::{Keymap, KeymapBuilder};
+pub use keymap::{Keymap, KeymapBuilder, WithoutIter};
 pub use keyset::{Keyset, KeysetBuilder};

--- a/packages/storage/src/lib.rs
+++ b/packages/storage/src/lib.rs
@@ -10,3 +10,10 @@ pub use deque_store::DequeStore;
 pub use item::Item;
 pub use keymap::{Keymap, KeymapBuilder};
 pub use keyset::{Keyset, KeysetBuilder};
+
+pub struct WithIter;
+pub struct WithoutIter;
+pub trait IterOption {}
+
+impl IterOption for WithIter {}
+impl IterOption for WithoutIter {}

--- a/packages/storage/src/lib.rs
+++ b/packages/storage/src/lib.rs
@@ -9,6 +9,7 @@ pub use append_store::AppendStore;
 pub use deque_store::DequeStore;
 pub use item::Item;
 pub use iter_options::WithoutIter;
+use iter_options::{IterOption, WithIter};
 pub use keymap::{Keymap, KeymapBuilder};
 pub use keyset::{Keyset, KeysetBuilder};
 

--- a/packages/storage/src/lib.rs
+++ b/packages/storage/src/lib.rs
@@ -3,8 +3,10 @@ pub mod append_store;
 pub mod deque_store;
 pub mod item;
 pub mod keymap;
+pub mod keyset;
 
 pub use append_store::AppendStore;
 pub use deque_store::DequeStore;
 pub use item::Item;
-pub use keymap::Keymap;
+pub use keymap::{Keymap, KeymapBuilder};
+pub use keyset::{Keyset, KeysetBuilder};

--- a/packages/storage/src/lib.rs
+++ b/packages/storage/src/lib.rs
@@ -8,12 +8,15 @@ pub mod keyset;
 pub use append_store::AppendStore;
 pub use deque_store::DequeStore;
 pub use item::Item;
+pub use iter_options::WithoutIter;
 pub use keymap::{Keymap, KeymapBuilder};
 pub use keyset::{Keyset, KeysetBuilder};
 
-pub struct WithIter;
-pub struct WithoutIter;
-pub trait IterOption {}
+pub mod iter_options {
+    pub struct WithIter;
+    pub struct WithoutIter;
+    pub trait IterOption {}
 
-impl IterOption for WithIter {}
-impl IterOption for WithoutIter {}
+    impl IterOption for WithIter {}
+    impl IterOption for WithoutIter {}
+}

--- a/packages/utils/src/feature_toggle.rs
+++ b/packages/utils/src/feature_toggle.rs
@@ -311,14 +311,14 @@ mod tests {
             None
         );
 
-        assert_eq!(
-            FeatureToggle::is_pauser(&storage, &Addr::unchecked("alice".to_string()))?,
-            true
-        );
-        assert_eq!(
-            FeatureToggle::is_pauser(&storage, &Addr::unchecked("bob".to_string()))?,
-            false
-        );
+        assert!(FeatureToggle::is_pauser(
+            &storage,
+            &Addr::unchecked("alice".to_string())
+        )?,);
+        assert!(!FeatureToggle::is_pauser(
+            &storage,
+            &Addr::unchecked("bob".to_string())
+        )?);
 
         Ok(())
     }


### PR DESCRIPTION
The following changes were made to the storage as mentioned in release notes, these changes were approved by @reuvenpo conceptually:

- Added the `Keyset` storage object (A hashset like storage object).
- Allowed further customisation of Keymap and Keyset with new constructor structs called `KeymapBuilder` and `KeysetBuilder` which allow the user to disable the iterator feature (saving gas) or adjust the internal indexes' page size so that the user may determine how many objects are to be stored/loaded together in the iterator.
- `::new_with_page_size(namespace, page_size)` method was added to `AppendStore` and `DequeStore` so that the user may adjust the internal indexes' page size which determine how many objects are to be stored/loaded together in the iterator.
- Minor performance upgrades to `Keymap`, `AppendStore`, and `DequeStore`.

Moreover, I also fixed all the clippy warnings and updated some readme files to reflect cosmwasm 1.0 changes. Cosmwasm v1.0 branch should probably be made default