### PR TITLE
bumping dependency to reference cosmwasm v1.1 on github

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,6 @@ members = ["packages/*"]
 
 [workspace.dependencies]
 schemars = { version = "0.8.11" }
-cosmwasm-std = { package = "secret-cosmwasm-std", version = "1.0.0" }
 serde = { version = "1.0" }
-cosmwasm-storage = { package = "secret-cosmwasm-storage", version = "1.0.0" }
+cosmwasm-std = { git = "https://github.com/scrtlabs/cosmwasm", tag = "v1.1.0-secret", package = "secret-cosmwasm-std" }
+cosmwasm-storage = { git = "https://github.com/scrtlabs/cosmwasm", tag = "v1.1.0-secret", package = "secret-cosmwasm-storage" }

--- a/packages/crypto/Cargo.toml
+++ b/packages/crypto/Cargo.toml
@@ -27,3 +27,4 @@ cosmwasm-std = { workspace = true }
 
 [dev-dependencies]
 secp256k1 = { version = "0.24.1", default-features = false, features=["alloc", "rand-std"] }
+base64 = "0.21.0"

--- a/packages/crypto/Readme.md
+++ b/packages/crypto/Readme.md
@@ -17,7 +17,7 @@ secret-toolkit-crypto = { version = "0.7.0", features = ["hash", "rand", "ecc-se
 
 ## Example usage
 
-```ignore
+```rust
 # extern crate secret_toolkit_crypto;
 
 # use secret_toolkit_crypto::{sha_256, Prng, secp256k1::{PrivateKey, PublicKey, Signature}};
@@ -25,7 +25,7 @@ secret-toolkit-crypto = { version = "0.7.0", features = ["hash", "rand", "ecc-se
 # use cosmwasm_std::{StdError, testing::mock_dependencies};
 
 # fn main() -> Result<(), StdError> {
-# let deps = mock_dependencies(20, &[]);
+# let deps = mock_dependencies();
 let entropy: String = "secret".to_owned();
 let prng_seed: Vec<u8> = sha_256(base64::encode(&entropy.clone()).as_bytes()).to_vec();
 

--- a/packages/crypto/src/secp256k1.rs
+++ b/packages/crypto/src/secp256k1.rs
@@ -23,7 +23,7 @@ impl PrivateKey {
     pub fn parse(raw: &[u8; PRIVATE_KEY_SIZE]) -> Result<Self, StdError> {
         secp256k1::SecretKey::from_slice(raw)
             .map(|key| PrivateKey { inner: key })
-            .map_err(|err| StdError::generic_err(format!("Error parsing PrivateKey: {}", err)))
+            .map_err(|err| StdError::generic_err(format!("Error parsing PrivateKey: {err}")))
     }
 
     pub fn serialize(&self) -> [u8; PRIVATE_KEY_SIZE] {
@@ -51,7 +51,7 @@ impl PublicKey {
     pub fn parse(p: &[u8]) -> Result<PublicKey, StdError> {
         secp256k1::PublicKey::from_slice(p)
             .map(|key| PublicKey { inner: key })
-            .map_err(|err| StdError::generic_err(format!("Error parsing PublicKey: {}", err)))
+            .map_err(|err| StdError::generic_err(format!("Error parsing PublicKey: {err}")))
     }
 
     pub fn serialize(&self) -> [u8; PUBLIC_KEY_SIZE] {
@@ -74,13 +74,13 @@ impl Signature {
     pub fn parse(p: &[u8; SIGNATURE_SIZE]) -> Result<Signature, StdError> {
         SecpSignature::from_compact(p)
             .map(|sig| Signature { inner: sig })
-            .map_err(|err| StdError::generic_err(format!("Error parsing Signature: {}", err)))
+            .map_err(|err| StdError::generic_err(format!("Error parsing Signature: {err}")))
     }
 
     pub fn parse_slice(p: &[u8]) -> Result<Signature, StdError> {
         SecpSignature::from_compact(p)
             .map(|sig| Signature { inner: sig })
-            .map_err(|err| StdError::generic_err(format!("Error parsing Signature: {}", err)))
+            .map_err(|err| StdError::generic_err(format!("Error parsing Signature: {err}")))
     }
 
     pub fn serialize(&self) -> [u8; SIGNATURE_SIZE] {

--- a/packages/incubator/src/generational_store.rs
+++ b/packages/incubator/src/generational_store.rs
@@ -583,7 +583,7 @@ where
 
     fn get_at_unchecked(&self, pos: u32) -> StdResult<Entry<T>> {
         let kind_plus_serialized = self.storage.get(&pos.to_be_bytes()).ok_or_else(|| {
-            StdError::generic_err(format!("No item in generational store at position {}", pos))
+            StdError::generic_err(format!("No item in generational store at position {pos}"))
         })?;
         if kind_plus_serialized.is_empty() {
             return Err(StdError::generic_err("Invalid data in generational store"));

--- a/packages/incubator/src/maxheap.rs
+++ b/packages/incubator/src/maxheap.rs
@@ -341,7 +341,7 @@ where
 
     fn get_at_unchecked(&self, pos: u32) -> StdResult<T> {
         let serialized = self.storage.get(&pos.to_be_bytes()).ok_or_else(|| {
-            StdError::generic_err(format!("No item in MaxHeapStore at position {}", pos))
+            StdError::generic_err(format!("No item in MaxHeapStore at position {pos}"))
         })?;
         Ser::deserialize(&serialized)
     }

--- a/packages/serialization/src/base64.rs
+++ b/packages/serialization/src/base64.rs
@@ -100,7 +100,7 @@ impl<'de, S: Serde, T: for<'des> de::Deserialize<'des>> de::Visitor<'de> for Bas
     {
         let binary = Base64::from_base64(v).map_err(|_| {
             //
-            E::custom(format!("invalid base64: {}", v))
+            E::custom(format!("invalid base64: {v}"))
         })?;
         match S::deserialize::<T>(binary.as_slice()) {
             Ok(val) => Ok(Base64Of::from(val)),

--- a/packages/snip20/src/query.rs
+++ b/packages/snip20/src/query.rs
@@ -212,7 +212,7 @@ impl QueryMsg {
                 msg,
             }))
             .map_err(|err| {
-                StdError::generic_err(format!("Error performing {} query: {}", self, err))
+                StdError::generic_err(format!("Error performing {self} query: {err}"))
             })
     }
 }

--- a/packages/snip721/Readme.md
+++ b/packages/snip721/Readme.md
@@ -12,26 +12,31 @@ Or you can call the individual function for each Handle message to generate the 
 
 Example:
 
-```ignore
-    let recipient = "ADDRESS_TO_TRANSFER_TO".to_string();
-    let token_id = "TOKEN_ID".to_string();
-    let memo = Some("TRANSFER_MEMO".to_string());
-    let padding = None;
-    let block_size = 256;
-    let callback_code_hash = "TOKEN_CONTRACT_CODE_HASH".to_string();
-    let contract_addr = "TOKEN_CONTRACT_ADDRESS".to_string();
+```rust
+# use cosmwasm_std::{Uint128, StdError, StdResult, CosmosMsg, Response};
+# use secret_toolkit_snip721::transfer_nft_msg;
+# fn main() -> StdResult<()> {
+let recipient = "ADDRESS_TO_TRANSFER_TO".to_string();
+let token_id = "TOKEN_ID".to_string();
+let memo = Some("TRANSFER_MEMO".to_string());
+let padding = None;
+let block_size = 256;
+let callback_code_hash = "TOKEN_CONTRACT_CODE_HASH".to_string();
+let contract_addr = "TOKEN_CONTRACT_ADDRESS".to_string();
 
-    let cosmos_msg = transfer_nft_msg(
-        recipient,
-        token_id,
-        memo,
-        padding,
-        block_size,
-        callback_code_hash,
-        contract_addr,
-    )?;
+let cosmos_msg = transfer_nft_msg(
+    recipient,
+    token_id,
+    memo,
+    padding,
+    block_size,
+    callback_code_hash,
+    contract_addr,
+)?;
 
-    Ok(Response::new().add_message(cosmos_msg))
+let response = Ok(Response::new().add_message(cosmos_msg));
+# response.map(|_r| ())
+# }
 ```
 
 All you have to do to call a SNIP-721 Handle function is call the appropriate toolkit function, and place the resulting `CosmosMsg` in the `messages` Vec of the InitResponse or HandleResponse.  In this example, we are transferring an NFT named "TOKEN_ID" to the recipient address.  We are not using the `padding` field of the Transfer message, but instead, we are padding the entire message to blocks of 256 bytes.
@@ -42,7 +47,8 @@ You probably have also noticed that CreateViewingKey is not supported.  This is 
 
 These are the types that the SNIP-721 toolkit queries can return
 
-```ignore
+```rust
+# use secret_toolkit_snip721::{Expiration};
 pub struct ContractInfo {
     pub name: String,
     pub symbol: String,
@@ -167,19 +173,35 @@ Or you can call the individual function for each query.
 
 Example:
 
-```ignore
-    let token_id = "TOKEN_ID".to_string();
-    let viewer = Some(ViewerInfo {
-        address: "VIEWER'S_ADDRESS".to_string(),
-        viewing_key: "VIEWER'S_KEY".to_string(),
-    });
-    let include_expired = None;
-    let block_size = 256;
-    let callback_code_hash = "TOKEN_CONTRACT_CODE_HASH".to_string();
-    let contract_addr = "TOKEN_CONTRACT_ADDRESS".to_string();
+```rust
+# use cosmwasm_std::{StdError, testing::mock_dependencies};
+# use secret_toolkit_snip721::{nft_dossier_query, ViewerInfo};
+# let mut deps = mock_dependencies();
+#
+let token_id = "TOKEN_ID".to_string();
+let viewer = Some(ViewerInfo {
+  address: "VIEWER'S_ADDRESS".to_string(),
+  viewing_key: "VIEWER'S_KEY".to_string(),
+});
+let include_expired = None;
+let block_size = 256;
+let callback_code_hash = "TOKEN_CONTRACT_CODE_HASH".to_string();
+let contract_addr = "TOKEN_CONTRACT_ADDRESS".to_string();
 
-    let nft_dossier =
-        nft_dossier_query(deps.querier, token_id, viewer, include_expired, block_size, callback_code_hash, contract_addr)?;
+let nft_dossier = nft_dossier_query(
+  deps.as_ref().querier,
+  token_id,
+  viewer,
+  include_expired,
+  block_size,
+  callback_code_hash,
+  contract_addr
+);
+#
+# assert_eq!(
+#     nft_dossier.unwrap_err().to_string(),
+#     "Generic error: Error performing NftDossier query: Generic error: Querier system error: No such contract: TOKEN_CONTRACT_ADDRESS"
+# );
 ```
 
 In this example, we are doing an NftDossier query on the token named "TOKEN_ID", supplying the address and viewing key of the querier, and storing the response in the nft_dossier variable, which is of the NftDossier type defined above.  Because no `include_expired` was specified, the response defaults to only displaying approvals that have not expired, but approvals will only be displayed if the viewer is the owner of the token.  The query message is padded to blocks of 256 bytes.

--- a/packages/snip721/src/expiration.rs
+++ b/packages/snip721/src/expiration.rs
@@ -19,8 +19,8 @@ pub enum Expiration {
 impl fmt::Display for Expiration {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Expiration::AtHeight(height) => write!(f, "expiration height: {}", height),
-            Expiration::AtTime(time) => write!(f, "expiration time: {}", time),
+            Expiration::AtHeight(height) => write!(f, "expiration height: {height}"),
+            Expiration::AtTime(time) => write!(f, "expiration time: {time}"),
             Expiration::Never => write!(f, "expiration: never"),
         }
     }

--- a/packages/snip721/src/query.rs
+++ b/packages/snip721/src/query.rs
@@ -469,7 +469,7 @@ impl QueryMsg {
                 msg,
             }))
             .map_err(|err| {
-                StdError::generic_err(format!("Error performing {} query: {}", self, err))
+                StdError::generic_err(format!("Error performing {self} query: {err}"))
             })
     }
 }

--- a/packages/utils/Cargo.toml
+++ b/packages/utils/Cargo.toml
@@ -17,4 +17,4 @@ all-features = true
 serde = {  workspace = true }
 schemars = { workspace = true }
 cosmwasm-std = {  workspace = true }
-cosmwasm-storage = { package = "secret-cosmwasm-storage", version = "1.0.0" }
+cosmwasm-storage = { workspace = true }

--- a/packages/utils/Readme.md
+++ b/packages/utils/Readme.md
@@ -16,7 +16,7 @@ elsewhere. There isn't an overarching theme for the items in this package.
 This module contains traits used to call another contract.  Do not forget to add the `use` statement for the traits you want.
 
 ```ignore
-use secret_toolkit::utils::{InitCallback, HandleCallback, Query};
+use secret_toolkit::utils::{InitCallback, HandleCallback};
 ```
 
 Also, don't forget to add the toolkit dependency to your Cargo.toml
@@ -25,7 +25,11 @@ Also, don't forget to add the toolkit dependency to your Cargo.toml
 
 If you want to instantiate another contract, you should first copy/paste the InitMsg of that contract.  For example, if you wanted to create an instance of the counter contract at <https://github.com/enigmampc/secret-template>
 
-```ignore
+```rust
+# use secret_toolkit_utils::InitCallback;
+# use serde::{Serialize, Deserialize};
+# use schemars::JsonSchema;
+#
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct CounterInitMsg {
     pub count: i32,
@@ -38,7 +42,23 @@ impl InitCallback for CounterInitMsg {
 
 You would copy/paste its InitMsg, and rename it so that it does not conflict with the InitMsg you have defined for your own contract.  Then you would implement the `InitCallback` trait as above, setting the BLOCK_SIZE constant to the size of the blocks you want your instantiation message padded to.
 
-```ignore
+```rust
+# use secret_toolkit_utils::InitCallback;
+# use cosmwasm_std::{StdResult, StdError, Response};
+# use serde::{Serialize, Deserialize};
+# use schemars::JsonSchema;
+#
+# #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+# pub struct CounterInitMsg {
+#     pub count: i32,
+# }
+#
+# impl InitCallback for CounterInitMsg {
+#     const BLOCK_SIZE: usize = 256;
+# }
+#
+# let response: StdResult<Response>;
+#
 let counter_init_msg = CounterInitMsg {
      count: 100 
 };
@@ -50,7 +70,8 @@ let cosmos_msg = counter_init_msg.to_cosmos_msg(
     None,
 )?;
 
-Ok(Response::new().add_message(cosmos_msg))
+response = Ok(Response::new().add_message(cosmos_msg));
+# Ok::<(), StdError>(())
 ```
 
 Next, in the init or handle function that will instantiate the other contract, you will create an instance of the CounterInitMsg, call its `to_cosmos_msg`, and place the resulting CosmosMsg in the `messages` Vec of the InitResponse or HandleResponse that your function is returning.  In this example, we are pretending that the code id of the counter contract is 123.  Also, in this example, you are not sending any SCRT with the InitMsg, but if you needed to send 1 SCRT, you would replace the None in the `to_cosmos_msg` call with `Some(Uint128(1000000))`.  The amount sent is in uscrt.  Any CosmosMsg placed in the `messages` Vec will be executed after your contract has finished its own processing.
@@ -59,7 +80,11 @@ Next, in the init or handle function that will instantiate the other contract, y
 
 You should first copy/paste the specific HandleMsg(s) you want to call.  For example, if you wanted to reset the counter you instantiated above
 
-```ignore
+```rust
+# use secret_toolkit_utils::HandleCallback;
+# use serde::{Serialize, Deserialize};
+# use schemars::JsonSchema;
+#
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub enum CounterHandleMsg {
     Reset { count: i32 },
@@ -72,7 +97,23 @@ impl HandleCallback for CounterHandleMsg {
 
 You would copy/paste the Reset variant of its HandleMsg enum, and rename the enum so that it does not conflict with the HandleMsg enum you have defined for your own contract.  Then you would implement the `HandleCallback` trait as above, setting the BLOCK_SIZE constant to the size of the blocks you want your Reset message padded to.  If you need to call multiple different Handle messages, even if they are to different contracts, you can include all the Handle messages as variants in the same enum (you can not have two variants with the same name within the same enum, though).
 
-```ignore
+```rust
+# use secret_toolkit_utils::HandleCallback;
+# use cosmwasm_std::{StdResult, StdError, Response};
+# use serde::{Serialize, Deserialize};
+# use schemars::JsonSchema;
+#
+# #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+# pub enum CounterHandleMsg {
+#     Reset { count: i32 },
+# }
+# 
+# impl HandleCallback for CounterHandleMsg {
+#     const BLOCK_SIZE: usize = 256;
+# }
+#
+# let response: StdResult<Response>;
+#
 let reset_msg = CounterHandleMsg::Reset {
     count: 200,
 };
@@ -83,7 +124,8 @@ let cosmos_msg = reset_msg.to_cosmos_msg(
     None,
 )?;
 
-Ok(Response::new().add_message(cosmos_msg))
+response = Ok(Response::new().add_message(cosmos_msg));
+# Ok::<(), StdError>(())
 ```
 
 Next, in the init or handle function that will call the other contract, you will create an instance of the CounterHandleMsg::Reset variant, call its `to_cosmos_msg`, and place the resulting CosmosMsg in the `messages` Vec of the InitResponse or HandleResponse that your function is returning.  In this example, you are not sending any SCRT with the Reset message, but if you needed to send 1 SCRT, you would replace the None in the `to_cosmos_msg` call with `Some(Uint128(1000000))`.  The amount sent is in uscrt.  Any CosmosMsg placed in the `messages` Vec will be executed after your contract has finished its own processing.
@@ -92,7 +134,11 @@ Next, in the init or handle function that will call the other contract, you will
 
 You should first copy/paste the specific QueryMsg(s) you want to call.  For example, if you wanted to get the count of the counter you instantiated above
 
-```ignore
+```rust
+# use secret_toolkit_utils::Query;
+# use serde::{Serialize, Deserialize};
+# use schemars::JsonSchema;
+#
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum CounterQueryMsg {
@@ -106,7 +152,11 @@ impl Query for CounterQueryMsg {
 
 You would copy/paste the GetCount variant of its QueryMsg enum, and rename the enum so that it does not conflict with the QueryMsg enum you have defined for your own contract.  Then you would implement the `Query` trait as above, setting the BLOCK_SIZE constant to the size of the blocks you want your query message padded to.  If you need to perform multiple different queries, even if they are to different contracts, you can include all the Query messages as variants in the same enum (you can not have two variants with the same name within the same enum, though).
 
-```ignore
+```rust
+# use secret_toolkit_utils::Query;
+# use serde::{Serialize, Deserialize};
+# use schemars::JsonSchema;
+#
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct CountResponse {
     pub count: i32,
@@ -117,7 +167,12 @@ Next, you will copy/paste the response of the query.  If the other contract defi
 
 If, however, the other contract returns an enum variant, one approach is to copy the fields of the variant and place them in a struct.  Because an enum variant gets serialized with the name of the variant, you will then also want to create a wrapper struct whose only field has the name of the variant, and whose type is the struct you defined with the variant's fields.  For example, if you wanted to do a token_info query of the [SNIP20 reference implementation](https://github.com/enigmampc/snip20-reference-impl), I would recommend using the SNIP20 toolkit function, but just for the sake of example, let's say you forgot that toolkit existed.
 
-```ignore
+```rust
+# use secret_toolkit_utils::Query;
+# use cosmwasm_std::Uint128;
+# use serde::{Serialize, Deserialize};
+# use schemars::JsonSchema;
+#
 #[derive(Serialize, Deserialize, JsonSchema, Debug)]
 pub struct TokenInfo {
     pub name: String,
@@ -136,13 +191,41 @@ You would copy the QueryAnswer::TokenInfo enum variant and create a TokenInfo st
 
 Now to perform the query
 
-```ignore
+```rust
+# use secret_toolkit_utils::Query;
+# use cosmwasm_std::{StdResult, StdError, Uint128, testing::mock_dependencies};
+# use serde::{Serialize, Deserialize};
+# use schemars::JsonSchema;
+#
+# #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+# #[serde(rename_all = "snake_case")]
+# pub enum CounterQueryMsg {
+#    GetCount {},
+# }
+# 
+# impl Query for CounterQueryMsg {
+#     const BLOCK_SIZE: usize = 256;
+# }
+#
+# #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+# pub struct CountResponse {
+#     pub count: i32,
+# }
+#
+# let deps = mock_dependencies();
+#
 let get_count = CounterQueryMsg::GetCount {};
-let count_response: CountResponse = get_count.query(
-    deps.querier,
+let count_response: StdResult<CountResponse> = get_count.query(
+    deps.as_ref().querier,
     "CODE_HASH_OF_CONTRACT_YOU_WANT_TO_QUERY".to_string(),
     "ADDRESS_OF_CONTRACT_YOU_ARE_QUERYING".to_string(),
-)?;
+);
+#
+# assert_eq!(
+#     count_response.unwrap_err().to_string(),
+#     "Generic error: Querier system error: No such contract: ADDRESS_OF_CONTRACT_YOU_ARE_QUERYING"
+# );
+# Ok::<(), StdError>(())
 ```
 
 You create an instance of the CounterQueryMsg::GetCount variant, and call its `query` function, returning its value to a variable of the response type.  If you were doing a token_info query, you would write `let token_info_resp: TokenInfoResponse = ...`.  You MUST use explicit type annotation here.
@@ -157,7 +240,19 @@ The feature toggles are designed to be flexible, so you can choose whether to pu
 
 Normally you'd want to initialize the features in the `instantiate()` function:
 
-```ignore
+```rust
+# use secret_toolkit_utils::feature_toggle::{FeatureToggle, FeatureStatus, FeatureToggleTrait};
+# use cosmwasm_std::{entry_point, DepsMut, Env, MessageInfo, StdResult, Response};
+# use serde::{Serialize};
+#
+# #[derive(Serialize)]
+# enum Features {
+#     Feature1,
+#     Feature2,
+# }
+#
+# struct InstantiateMsg { }
+#
 #[entry_point]
 pub fn instantiate(
     deps: DepsMut,
@@ -179,13 +274,17 @@ pub fn instantiate(
         ],
         vec![info.sender], // Can put more than one pauser
     )?;
+    
+    Ok(Response::new())
 }
 ```
 
 The feature field in `FeatureStatus` can be anything, as long as it's implementing `serde::Serialize`.
 In this example it's:
 
-```ignore
+```rust
+# use serde::{Serialize};
+#
 #[derive(Serialize)]
 pub enum Features {
     Feature1,
@@ -195,7 +294,10 @@ pub enum Features {
 
 For the `status` field, you should use the built-in `FeatureToggle::Status` enum:
 
-```ignore
+```rust
+# use serde::{Serialize, Deserialize};
+# use schemars::JsonSchema;
+#
 #[derive(Serialize, Debug, Deserialize, Clone, JsonSchema, PartialEq)]
 pub enum Status {
     NotPaused,
@@ -209,15 +311,25 @@ The defult value of `Status` is `Status::NotPaused`.
 
 Putting a toggle on a message (or any code section of your choosing) is as easy as calling `FeatureToggle::require_not_paused()`. For example if we have a `Redeem` message in our contract, and we initialized the feature as `Features::Redeem`:
 
-```ignore
+```rust
+# use cosmwasm_std::{DepsMut, Env, StdResult, Response};
+# use secret_toolkit_utils::feature_toggle::{FeatureToggle, FeatureToggleTrait};
+# use serde::{Serialize};
+#
+# #[derive(Serialize)]
+# pub enum Features {
+#     Redeem,
+# }
+#
 fn redeem(
     deps: DepsMut,
     env: Env,
     amount: Option<u128>,
 ) -> StdResult<Response> {
-    FeatureToggle::require_not_paused(&deps.storage, vec![Features::Redeem])?;
+    FeatureToggle::require_not_paused(deps.as_ref().storage, vec![Features::Redeem])?;
     
     // Continue with function's operation
+    Ok(Response::new())
 }
 ```
 
@@ -227,7 +339,16 @@ If the status of the `Features::Redeem` feature is `Paused`, the contract will e
 
 Firstly, we will need to add `Pause` and `Unpause` messages in our `HandleMsg` enum. We can simply use `FeatureToggle::FeatureToggleHandleMsg` - it's an enum that contains default messages that `FeatureToggle` also has default implementation for:
 
-```ignore
+```rust
+# use cosmwasm_std::Uint128;
+# use secret_toolkit_utils::feature_toggle::FeatureToggleHandleMsg;
+# use serde::{Serialize, Deserialize};
+#
+# #[derive(Serialize, Deserialize)]
+# pub enum Features {
+#     Redeem,
+# }
+#
 pub enum ExecuteMsg {
     // Contract messages
     Redeem {
@@ -236,13 +357,36 @@ pub enum ExecuteMsg {
     Etc {}, //..
 
     // Feature toggle
-    Features(FeatureToggleHandleMsg),
+    Features(FeatureToggleHandleMsg::<Features>),
 }
 ```
 
 The `FeatureToggle` struct contains a default implementation for triggering (pausing/unpausing) a feature, so you can just call it from your `execute()` function:
 
-```ignore
+```rust
+# use secret_toolkit_utils::feature_toggle::{FeatureToggle, FeatureToggleTrait, FeatureToggleHandleMsg};
+# use cosmwasm_std::{entry_point, DepsMut, Env, MessageInfo, StdResult, Response, Uint128, Addr};
+# use serde::{Serialize, Deserialize};
+#
+# #[derive(Serialize, Deserialize)]
+# enum Features {
+#     Feature1,
+#     Feature2,
+# }
+#
+# pub enum ExecuteMsg {
+#     // Contract messages
+#     Redeem {
+#         amount: Option<Uint128>,
+#     },
+#     Etc {}, //..
+#     // Feature toggle
+#     Features(FeatureToggleHandleMsg::<Features>),
+# }
+#
+# fn redeem(_deps: DepsMut, _env: Env, _amount: Option<Uint128>) -> StdResult<Response> { Ok(Response::new()) }
+# fn etc(_deps: DepsMut, _env: Env) -> StdResult<Response> { Ok(Response::new()) }
+#
 #[entry_point]
 pub fn execute(
     deps: DepsMut,
@@ -254,8 +398,10 @@ pub fn execute(
         ExecuteMsg::Redeem { amount } => redeem(deps, env, amount),
         ExecuteMsg::Etc {} => etc(deps, env),
         ExecuteMsg::Features(m) => match m {
-            FeatureToggleHandleMsg::Pause { features } => FeatureToggle::handle_pause(deps, env, features),
-            FeatureToggleHandleMsg::Unpause { features } => FeatureToggle::handle_unpause(deps, env, features),
+            FeatureToggleHandleMsg::Pause { features } => FeatureToggle::handle_pause(deps, &info, features),
+            FeatureToggleHandleMsg::Unpause { features } => FeatureToggle::handle_unpause(deps, &info, features),
+            // `SetPauser` and `RemovePauser` go here too
+            # _ => Ok(Response::new())
         },
     }
 }
@@ -271,7 +417,29 @@ Note: you should only add `Features(FeatureToggleHandleMsg)` to the `HandleMsg` 
 
 `FeatureToggle` provides with default implementation for these too, but you can wrap it with your own logic like requiring the caller to be admin, etc.:
 
-```ignore
+```rust
+# use cosmwasm_std::{entry_point, DepsMut, Env, MessageInfo, StdResult, Response, Uint128, Addr, StdError};
+# use secret_toolkit_utils::feature_toggle::{FeatureToggle, FeatureToggleTrait, FeatureToggleHandleMsg};
+# use serde::{Serialize, Deserialize};
+#
+# #[derive(Serialize, Deserialize)]
+# enum Features {
+#     Feature1,
+#     Feature2,
+# }
+#
+# pub enum ExecuteMsg {
+#     // Contract messages
+#     Redeem {
+#         amount: Option<Uint128>,
+#     },
+#     // Feature toggle
+#     Features(FeatureToggleHandleMsg::<Features>),
+# }
+#
+# fn redeem(_deps: DepsMut, _env: Env, _amount: Option<Uint128>) -> StdResult<Response> { Ok(Response::new()) }
+# fn get_admin() -> StdResult<Addr> { Ok(Addr::unchecked("admin")) }
+#
 #[entry_point]
 pub fn execute(
     deps: DepsMut,
@@ -283,9 +451,10 @@ pub fn execute(
     match msg {
         ExecuteMsg::Redeem { amount } => redeem(deps, env, amount),
         ExecuteMsg::Features(m) => match m {
-            // `Stop` and `Resume` go here too
             FeatureToggleHandleMsg::SetPauser { address } => set_pauser(deps, info, address),
             FeatureToggleHandleMsg::RemovePauser { address } => remove_pauser(deps, info, address),
+            // `Pause` and `Unpause` go here too
+            # _ => Ok(Response::new())
         },
     }
 }
@@ -294,13 +463,14 @@ fn set_pauser(
     deps: DepsMut,
     info: MessageInfo,
     address: String,
-) -> StdResult<HandleResponse> {
+) -> StdResult<Response> {
     let admin = get_admin()?;
     if admin != info.sender {
-        return Err(StdError::unauthorized());
+        return Err(StdError::generic_err("Unauthorized"));
     }
 
-    FeatureToggle::handle_set_pauser(deps, env, address)
+    let address = deps.api.addr_validate(&address)?;
+    FeatureToggle::handle_set_pauser(deps, address)
 }
 
 fn remove_pauser(
@@ -310,10 +480,11 @@ fn remove_pauser(
 ) -> StdResult<Response> {
     let admin = get_admin()?;
     if admin != info.sender {
-        return Err(StdError::unauthorized());
+        return Err(StdError::generic_err("Unauthorized"));
     }
 
-    FeatureToggle::handle_remove_pauser(deps, env, address)
+    let address = deps.api.addr_validate(&address)?;
+    FeatureToggle::handle_remove_pauser(deps, address)
 }
 ```
 
@@ -323,7 +494,11 @@ Note: `set_pauser` and `remove_pauser` are permissionless by default.
 
 If you don't like the default implementation or want to override it for any other reason (for example, using a different storage namespace), you can do that by defining your own struct and implement `FeatureToggleTrait` for it:
 
-```ignore
+```rust
+# use cosmwasm_std::{Storage, StdResult};
+# use secret_toolkit_utils::feature_toggle::{FeatureToggleTrait, Status};
+# use serde::Serialize;
+#
 struct TrollFeatureToggle {}
 
 impl FeatureToggleTrait for TrollFeatureToggle {
@@ -354,11 +529,14 @@ impl FeatureToggleTrait for TrollFeatureToggle {
 
 Similarly to `FeatureToggleHandleMsg`, query messages (and default implementations) are also provided:
 
-```ignore
+```rust
+# use serde::{Serialize, Deserialize, de::DeserializeOwned};
+# use schemars::JsonSchema;
+#
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum FeatureToggleQueryMsg<T: Serialize + DeserializeOwned> {
-    #[serde(bound = "")] // don't ask
+    # #[serde(bound = "")]
     Status {
         features: Vec<T>,
     },


### PR DESCRIPTION
There's also the [`testable-readmes`](https://github.com/scrtlabs/secret-toolkit/pull/70) branch, which made the README examples testable. It tested this change on more examples.