### PR TITLE
Keymap and Keyset paging bug is fixed. And using the new base64 encode api

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fixed a bug in `Keymap` and `Keyset` (#84).
 - SecureItem - storage access pattern obfuscating Item (#82).
 - Change the internal `rng` field of the `Prng` struct to be public (#81),
 

--- a/packages/storage/src/append_store.rs
+++ b/packages/storage/src/append_store.rs
@@ -836,4 +836,22 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn test_paging_last_page() -> StdResult<()> {
+        let mut storage = MockStorage::new();
+        let append_store: AppendStore<u32> = AppendStore::new(b"test");
+
+        let total_items: u32 = 20;
+
+        for i in 0..total_items {
+            append_store.push(&mut storage, &i)?;
+        }
+
+        assert_eq!(append_store.paging(&storage, 0, 23)?.len(), 20);
+        assert_eq!(append_store.paging(&storage, 2, 8)?.len(), 4);
+        assert_eq!(append_store.paging(&storage, 2, 7)?.len(), 6);
+
+        Ok(())
+    }
 }

--- a/packages/storage/src/deque_store.rs
+++ b/packages/storage/src/deque_store.rs
@@ -955,25 +955,43 @@ mod tests {
     #[test]
     fn test_paging() -> StdResult<()> {
         let mut storage = MockStorage::new();
-        let append_store: DequeStore<u32> = DequeStore::new(b"test");
+        let deque_store: DequeStore<u32> = DequeStore::new(b"test");
 
         let page_size: u32 = 5;
         let total_items: u32 = 50;
 
         for j in 0..total_items {
             let i = total_items - j;
-            append_store.push_front(&mut storage, &i)?;
+            deque_store.push_front(&mut storage, &i)?;
         }
 
         for i in 0..((total_items / page_size) - 1) {
             let start_page = i;
 
-            let values = append_store.paging(&storage, start_page, page_size)?;
+            let values = deque_store.paging(&storage, start_page, page_size)?;
 
             for (index, value) in values.iter().enumerate() {
                 assert_eq!(value, &(page_size * start_page + index as u32 + 1))
             }
         }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_paging_last_page() -> StdResult<()> {
+        let mut storage = MockStorage::new();
+        let deque_store: DequeStore<u32> = DequeStore::new(b"test");
+
+        let total_items: u32 = 20;
+
+        for i in 0..total_items {
+            deque_store.push_back(&mut storage, &i)?;
+        }
+
+        assert_eq!(deque_store.paging(&storage, 0, 23)?.len(), 20);
+        assert_eq!(deque_store.paging(&storage, 2, 8)?.len(), 4);
+        assert_eq!(deque_store.paging(&storage, 2, 7)?.len(), 6);
 
         Ok(())
     }

--- a/packages/storage/src/keymap.rs
+++ b/packages/storage/src/keymap.rs
@@ -996,12 +996,12 @@ mod tests {
     fn test_keymap_perf_insert() -> StdResult<()> {
         let mut storage = MockStorage::new();
 
-        let total_items = 1000;
+        let total_items: i32 = 1000;
 
         let keymap: Keymap<Vec<u8>, i32> = Keymap::new(b"test");
 
         for i in 0..total_items {
-            let key: Vec<u8> = (i as i32).to_be_bytes().to_vec();
+            let key: Vec<u8> = i.to_be_bytes().to_vec();
             keymap.insert(&mut storage, &key, &i)?;
         }
 

--- a/packages/storage/src/keymap.rs
+++ b/packages/storage/src/keymap.rs
@@ -487,7 +487,7 @@ impl<'a, K: Serialize + DeserializeOwned, T: Serialize + DeserializeOwned, Ser: 
         }
 
         self.iter_keys(storage)?
-            .skip((start_page as usize) * (size as usize))
+            .skip(start_pos as usize)
             .take(size as usize)
             .collect()
     }

--- a/packages/storage/src/keymap.rs
+++ b/packages/storage/src/keymap.rs
@@ -446,7 +446,6 @@ impl<'a, K: Serialize + DeserializeOwned, T: Serialize + DeserializeOwned, Ser: 
         size: u32,
     ) -> StdResult<Vec<(K, T)>> {
         let start_pos = start_page * size;
-        let mut end_pos = start_pos + size - 1;
 
         let max_size = self.get_len(storage)?;
 
@@ -458,10 +457,12 @@ impl<'a, K: Serialize + DeserializeOwned, T: Serialize + DeserializeOwned, Ser: 
             return Err(StdError::NotFound {
                 kind: "out of bounds".to_string(),
             });
-        } else if end_pos >= max_size {
-            end_pos = max_size - 1;
         }
-        self.get_pairs_at_positions(storage, start_pos, end_pos)
+
+        self.iter(storage)?
+            .skip(start_pos as usize)
+            .take(size as usize)
+            .collect()
     }
 
     /// paginates only the keys. More efficient than paginating both items and keys
@@ -472,7 +473,6 @@ impl<'a, K: Serialize + DeserializeOwned, T: Serialize + DeserializeOwned, Ser: 
         size: u32,
     ) -> StdResult<Vec<K>> {
         let start_pos = start_page * size;
-        let mut end_pos = start_pos + size - 1;
 
         let max_size = self.get_len(storage)?;
 
@@ -484,77 +484,12 @@ impl<'a, K: Serialize + DeserializeOwned, T: Serialize + DeserializeOwned, Ser: 
             return Err(StdError::NotFound {
                 kind: "out of bounds".to_string(),
             });
-        } else if end_pos >= max_size {
-            end_pos = max_size - 1;
         }
-        self.get_keys_at_positions(storage, start_pos, end_pos)
-    }
 
-    /// tries to list keys without checking start/end bounds
-    fn get_keys_at_positions(
-        &self,
-        storage: &dyn Storage,
-        start: u32,
-        end: u32,
-    ) -> StdResult<Vec<K>> {
-        let start_page = self.page_from_position(start);
-        let end_page = self.page_from_position(end);
-
-        let mut res = vec![];
-
-        for page in start_page..=end_page {
-            let indexes = self.get_indexes(storage, page)?;
-            let start_page_pos = if page == start_page {
-                start % self.page_size
-            } else {
-                0
-            };
-            let end_page_pos = if page == end_page {
-                end % self.page_size
-            } else {
-                self.page_size - 1
-            };
-            for i in start_page_pos..=end_page_pos {
-                let key_vec = &indexes[i as usize];
-                let key = self.deserialize_key(key_vec)?;
-                res.push(key);
-            }
-        }
-        Ok(res)
-    }
-
-    /// tries to list (key, item) pairs without checking start/end bounds
-    fn get_pairs_at_positions(
-        &self,
-        storage: &dyn Storage,
-        start: u32,
-        end: u32,
-    ) -> StdResult<Vec<(K, T)>> {
-        let start_page = self.page_from_position(start);
-        let end_page = self.page_from_position(end);
-
-        let mut res = vec![];
-
-        for page in start_page..=end_page {
-            let indexes = self.get_indexes(storage, page)?;
-            let start_page_pos = if page == start_page {
-                start % self.page_size
-            } else {
-                0
-            };
-            let end_page_pos = if page == end_page {
-                end % self.page_size
-            } else {
-                self.page_size - 1
-            };
-            for i in start_page_pos..=end_page_pos {
-                let key_vec = &indexes[i as usize];
-                let key = self.deserialize_key(key_vec)?;
-                let item = self.load_impl(storage, key_vec)?.get_item()?;
-                res.push((key, item));
-            }
-        }
-        Ok(res)
+        self.iter_keys(storage)?
+            .skip((start_page as usize) * (size as usize))
+            .take(size as usize)
+            .collect()
     }
 
     /// Returns a readonly iterator only for keys. More efficient than iter().

--- a/packages/viewing_key/Cargo.toml
+++ b/packages/viewing_key/Cargo.toml
@@ -16,7 +16,7 @@ all-features = true
 [dependencies]
 serde = {  workspace = true }
 schemars = { workspace = true }
-base64 = "0.13.0"
+base64 = "0.21.0"
 subtle = { version = "2.2.3", default-features = false }
 cosmwasm-std = { workspace = true }
 cosmwasm-storage = { workspace = true }

--- a/packages/viewing_key/src/lib.rs
+++ b/packages/viewing_key/src/lib.rs
@@ -2,6 +2,7 @@
 
 extern crate core;
 
+use base64::{engine, Engine};
 use subtle::ConstantTimeEq;
 
 use cosmwasm_std::{Env, MessageInfo, StdError, StdResult, Storage};
@@ -107,7 +108,8 @@ fn new_viewing_key(
 
     let key = sha_256(&rand_slice);
 
-    let viewing_key = VIEWING_KEY_PREFIX.to_string() + &base64::encode(key);
+    let viewing_key =
+        VIEWING_KEY_PREFIX.to_string() + &engine::general_purpose::STANDARD.encode(key);
     (viewing_key, rand_slice)
 }
 

--- a/packages/viewing_key/src/lib.rs
+++ b/packages/viewing_key/src/lib.rs
@@ -2,7 +2,7 @@
 
 extern crate core;
 
-use base64::{engine, Engine};
+use base64::{engine::general_purpose, Engine as _};
 use subtle::ConstantTimeEq;
 
 use cosmwasm_std::{Env, MessageInfo, StdError, StdResult, Storage};
@@ -108,8 +108,7 @@ fn new_viewing_key(
 
     let key = sha_256(&rand_slice);
 
-    let viewing_key =
-        VIEWING_KEY_PREFIX.to_string() + &engine::general_purpose::STANDARD.encode(key);
+    let viewing_key = VIEWING_KEY_PREFIX.to_string() + &general_purpose::STANDARD.encode(key);
     (viewing_key, rand_slice)
 }
 


### PR DESCRIPTION
Keymap and keyset's paging api's now use `.iter` method for paging. This improves readability and fixes a recent bug found in `.paging` method where querying the last available page can panic in some edge cases.
Unrelated change: in `viewing_key` package, I stopped using the depreciated base64 api to stop clippy complaint