### PR TITLE
Fixed a remove bug in Keymap and Keyset

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fixed a remove bug in `Keymap` and `Keyset` ([#86](https://github.com/scrtlabs/secret-toolkit/pull/86)).
+
 ## v0.8.1
 
 ### Bug fixes
@@ -123,9 +125,9 @@ A full guide to using the new `storage` types can be found
 ### Breaking
 
 - `secret-toolkit::permit::validate()` Now supports validating any type of Cosmos address.
-Interface changes: Now takes a reference to the current token address instead
-of taking it by value and an optional hrp string.
-In addition, it returns a String and not HumanAddr.
+  Interface changes: Now takes a reference to the current token address instead
+  of taking it by value and an optional hrp string.
+  In addition, it returns a String and not HumanAddr.
 
 - Renamed `secret-toolkit::permit::Permission` to `secret-toolkit::permit::TokenPermission`.
 - `secret-toolkit-crypto` now has features `["hash", "rng" and "ecc-secp256k1"]` which are all off by default - enable those you need.
@@ -149,16 +151,16 @@ This version is also the first released to [crates.io](https://crates.io)!
 - Added support for SNIP-23 messages (improved Send operations) which broke some interfaces
 - Added support for SNIP-24 permits
 - Added `Base64Of<S: Serde, T>`, `Base64JsonOf<T>`, and `Base64Bincode2Of<T>`,
-    which are wrappers that automatically deserializes base64 strings to `T`.
-    It can be used in message types' fields instead of `Binary` when the contents of the string
-    should have more specific contents.
+  which are wrappers that automatically deserializes base64 strings to `T`.
+  It can be used in message types' fields instead of `Binary` when the contents of the string
+  should have more specific contents.
 
 - Added `storage::DequeStore` - Similar to `AppendStore` but allows pushing and popping on both ends
 - Added the `secret-toolkit::incubator` package intended for experimental features. It contains:
   - `CashMap` - A hashmap like storage abstraction
   - `GenerationalIndex` - A generational index storage abstraction
 - The various subpackages can now be selected using feature flags. The default flags are `["serialization", "snip20", "snip721", "storage", "utils"]`
-    while `["crypto", "permit", "incubator"]` are left disabled by default.
+  while `["crypto", "permit", "incubator"]` are left disabled by default.
 
 ## v0.1.1
 
@@ -183,4 +185,4 @@ This is the first release of `secret-toolkit`. It supports:
 - `secret-toolkit::utils` - General utilities for writing contract code.
   - `padding` - tools for padding queries and responses.
   - `calls` - Tools for marking types as messages in queries and callbacks
-      to other contracts.
+    to other contracts.

--- a/packages/storage/src/keymap.rs
+++ b/packages/storage/src/keymap.rs
@@ -367,6 +367,7 @@ impl<'a, K: Serialize + DeserializeOwned, T: Serialize + DeserializeOwned, Ser: 
         if len == 0 || len == removed_pos {
             indexes.pop();
             self.set_indexes_page(storage, page, &indexes)?;
+            self.remove_impl(storage, &key_vec);
             return Ok(());
         }
 
@@ -1496,6 +1497,19 @@ mod tests {
         assert_eq!(keymap.paging(&storage, 2, 7)?.len(), 6);
         assert_eq!(keymap.paging_keys(&storage, 2, 7)?.len(), 6);
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_add_remove_one() -> StdResult<()> {
+        let mut storage = MockStorage::new();
+        let keymap: Keymap<i32, i32> = Keymap::new(b"test");
+        keymap.insert(&mut storage, &1, &1)?;
+        assert_eq!(keymap.get_len(&storage)?, 1);
+        keymap.remove(&mut storage, &1)?;
+        assert_eq!(keymap.get_len(&storage)?, 0);
+        keymap.insert(&mut storage, &1, &1)?;
+        assert_eq!(keymap.get_len(&storage)?, 1);
         Ok(())
     }
 }

--- a/packages/storage/src/keymap.rs
+++ b/packages/storage/src/keymap.rs
@@ -1508,6 +1508,7 @@ mod tests {
         assert_eq!(keymap.get_len(&storage)?, 1);
         keymap.remove(&mut storage, &1)?;
         assert_eq!(keymap.get_len(&storage)?, 0);
+        assert!(keymap.get(&storage, &1).is_none());
         keymap.insert(&mut storage, &1, &1)?;
         assert_eq!(keymap.get_len(&storage)?, 1);
         Ok(())

--- a/packages/storage/src/keyset.rs
+++ b/packages/storage/src/keyset.rs
@@ -1057,6 +1057,7 @@ mod tests {
         assert_eq!(keyset.get_len(&storage)?, 1);
         keyset.remove(&mut storage, &1)?;
         assert_eq!(keyset.get_len(&storage)?, 0);
+        assert!(!keyset.contains(&storage, &1));
         keyset.insert(&mut storage, &1)?;
         assert_eq!(keyset.get_len(&storage)?, 1);
         Ok(())

--- a/packages/storage/src/keyset.rs
+++ b/packages/storage/src/keyset.rs
@@ -343,6 +343,7 @@ impl<'a, K: Serialize + DeserializeOwned, Ser: Serde> Keyset<'a, K, Ser, WithIte
         if len == 0 || len == removed_pos {
             indexes.pop();
             self.set_indexes_page(storage, page, &indexes)?;
+            storage.remove(&key_vec);
             return Ok(());
         }
 
@@ -1045,6 +1046,19 @@ mod tests {
         assert_eq!(keyset.paging(&storage, 2, 8)?.len(), 4);
         assert_eq!(keyset.paging(&storage, 2, 7)?.len(), 6);
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_add_remove_one() -> StdResult<()> {
+        let mut storage = MockStorage::new();
+        let keyset: Keyset<i32> = Keyset::new(b"test");
+        keyset.insert(&mut storage, &1)?;
+        assert_eq!(keyset.get_len(&storage)?, 1);
+        keyset.remove(&mut storage, &1)?;
+        assert_eq!(keyset.get_len(&storage)?, 0);
+        keyset.insert(&mut storage, &1)?;
+        assert_eq!(keyset.get_len(&storage)?, 1);
         Ok(())
     }
 }


### PR DESCRIPTION
The issue is highlighted in the last test. The issue was that if you remove the last object in the list, some metadata survives which becomes a problem when you attempt to reinsert the same item in the future.