### PR TITLE
Submessage Funds 

### DIFF
--- a/packages/utils/Readme.md
+++ b/packages/utils/Readme.md
@@ -77,7 +77,7 @@ response = Ok(Response::new().add_message(cosmos_msg));
 # Ok::<(), StdError>(())
 ```
 
-Next, in the init or handle function that will instantiate the other contract, you will create an instance of the CounterInitMsg, call its `to_cosmos_msg`, and place the resulting CosmosMsg in the `messages` Vec of the InitResponse or HandleResponse that your function is returning. In this example, we are pretending that the code id of the counter contract is 123. Also, in this example, you are not sending any SCRT with the InitMsg, but if you needed to send 1 SCRT, you would replace the None in the `to_cosmos_msg` call with `Some(Uint128(1000000))`. The amount sent is in uscrt. Any CosmosMsg placed in the `messages` Vec will be executed after your contract has finished its own processing.
+Next, in the init or handle function that will instantiate the other contract, you will create an instance of the CounterInitMsg, call its `to_cosmos_msg`, and place the resulting CosmosMsg in the `messages` Vec of the InitResponse or HandleResponse that your function is returning. In this example, we are pretending that the code id of the counter contract is 123. Also, in this example, you are sending 1234 SCRT with the InitMsg as seen in the `funds` parameter. The amount sent is in uscrt, but it can be sent in any denom of your choice. Any CosmosMsg placed in the `messages` Vec will be executed after your contract has finished its own processing.
 
 ### Calling a handle function of another contract
 
@@ -133,7 +133,7 @@ response = Ok(Response::new().add_message(cosmos_msg));
 # Ok::<(), StdError>(())
 ```
 
-Next, in the init or handle function that will call the other contract, you will create an instance of the CounterHandleMsg::Reset variant, call its `to_cosmos_msg`, and place the resulting CosmosMsg in the `messages` Vec of the InitResponse or HandleResponse that your function is returning. In this example, you are not sending any SCRT with the Reset message, but if you needed to send 1 SCRT, you would replace the None in the `to_cosmos_msg` call with `Some(Uint128(1000000))`. The amount sent is in uscrt. Any CosmosMsg placed in the `messages` Vec will be executed after your contract has finished its own processing.
+Next, in the init or handle function that will call the other contract, you will create an instance of the CounterHandleMsg::Reset variant, call its `to_cosmos_msg`, and place the resulting CosmosMsg in the `messages` Vec of the InitResponse or HandleResponse that your function is returning. In this example, you are sending 1234 SCRT with the Reset message, as seen in the `funds` parameter. The amount sent is in uscrt, but it can be sent in any denom of your choice. Any CosmosMsg placed in the `messages` Vec will be executed after your contract has finished its own processing.
 
 ### Querying another contract
 

--- a/packages/utils/Readme.md
+++ b/packages/utils/Readme.md
@@ -44,7 +44,7 @@ You would copy/paste its InitMsg, and rename it so that it does not conflict wit
 
 ```rust
 # use secret_toolkit_utils::InitCallback;
-# use cosmwasm_std::{StdResult, StdError, Response};
+# use cosmwasm_std::{StdResult, StdError, Response, Coin};
 # use serde::{Serialize, Deserialize};
 # use schemars::JsonSchema;
 #
@@ -63,12 +63,14 @@ let counter_init_msg = CounterInitMsg {
      count: 100
 };
 
+let funds = vec![Coin::new(1234, "uscrt")];
+
 let cosmos_msg = counter_init_msg.to_cosmos_msg(
     None,
     "new_contract_label".to_string(),
     123,
     "CODE_HASH_OF_CONTRACT_YOU_WANT_TO_INSTANTIATE".to_string(),
-    None,
+    funds,
 )?;
 
 response = Ok(Response::new().add_message(cosmos_msg));
@@ -100,7 +102,7 @@ You would copy/paste the Reset variant of its HandleMsg enum, and rename the enu
 
 ```rust
 # use secret_toolkit_utils::HandleCallback;
-# use cosmwasm_std::{StdResult, StdError, Response};
+# use cosmwasm_std::{StdResult, StdError, Response, Coin};
 # use serde::{Serialize, Deserialize};
 # use schemars::JsonSchema;
 #
@@ -119,10 +121,12 @@ let reset_msg = CounterHandleMsg::Reset {
     count: 200,
 };
 
+let funds = vec![Coin::new(1234, "uscrt")];
+
 let cosmos_msg = reset_msg.to_cosmos_msg(
     "CODE_HASH_OF_CONTRACT_YOU_WANT_TO_EXECUTE".to_string(),
     "ADDRESS_OF_CONTRACT_YOU_ARE_CALLING".to_string(),
-    None,
+    funds,
 )?;
 
 response = Ok(Response::new().add_message(cosmos_msg));


### PR DESCRIPTION
Update calls.rs  `fn to_cosmos_msg()` to accept Vec<Coin> for `funds` parameter with passing tests. 