### PR TITLE
add token_subtype metadata

### DIFF
--- a/packages/snip721/src/handle.rs
+++ b/packages/snip721/src/handle.rs
@@ -1296,6 +1296,7 @@ mod tests {
                 youtube_url: None,
                 media: None,
                 protected_attributes: None,
+                token_subtype: None,
             }),
         });
         let private_metadata = Some(Metadata {
@@ -1317,6 +1318,7 @@ mod tests {
                 youtube_url: None,
                 media: None,
                 protected_attributes: None,
+                token_subtype: None,
             }),
         });
         let memo = Some("memo".to_string());
@@ -1462,6 +1464,7 @@ mod tests {
                 youtube_url: None,
                 media: None,
                 protected_attributes: None,
+                token_subtype: None,
             }),
         });
         let private_metadata = Some(Metadata {
@@ -1483,6 +1486,7 @@ mod tests {
                 youtube_url: None,
                 media: None,
                 protected_attributes: None,
+                token_subtype: None,
             }),
         });
         let padding = None;
@@ -1540,6 +1544,7 @@ mod tests {
                         youtube_url: None,
                         media: None,
                         protected_attributes: None,
+                        token_subtype: None,
                     }),
                 }),
                 private_metadata: None,
@@ -1567,6 +1572,7 @@ mod tests {
                         youtube_url: None,
                         media: None,
                         protected_attributes: None,
+                        token_subtype: None,
                     }),
                 }),
                 private_metadata: Some(Metadata {
@@ -1588,6 +1594,7 @@ mod tests {
                         youtube_url: None,
                         media: None,
                         protected_attributes: None,
+                        token_subtype: None,
                     }),
                 }),
                 memo: None,
@@ -1615,6 +1622,7 @@ mod tests {
                         youtube_url: None,
                         media: None,
                         protected_attributes: None,
+                        token_subtype: None,
                     }),
                 }),
                 memo: Some("memo 3".to_string()),

--- a/packages/snip721/src/metadata.rs
+++ b/packages/snip721/src/metadata.rs
@@ -46,6 +46,9 @@ pub struct Extension {
     /// a select list of trait_types that are in the private metadata.  This will only ever be used
     /// in public metadata
     pub protected_attributes: Option<Vec<String>>,
+    /// token subtypes used by Stashh for display groupings (primarily used for badges, which are specified
+    /// by using "badge" as the token_subtype)
+    pub token_subtype: Option<String>,
 }
 
 /// attribute trait

--- a/packages/snip721/src/query.rs
+++ b/packages/snip721/src/query.rs
@@ -1323,6 +1323,7 @@ mod tests {
                             youtube_url: None,
                             media: None,
                             protected_attributes: None,
+                            token_subtype: None,
                         }),
                     },
                 };
@@ -1357,6 +1358,7 @@ mod tests {
                 youtube_url: None,
                 media: None,
                 protected_attributes: None,
+                token_subtype: None,
             }),
         };
 
@@ -1431,6 +1433,7 @@ mod tests {
                                 youtube_url: None,
                                 media: None,
                                 protected_attributes: None,
+                                token_subtype: None,
                             }),
                         }),
                     },
@@ -1485,6 +1488,7 @@ mod tests {
                     youtube_url: None,
                     media: None,
                     protected_attributes: None,
+                    token_subtype: None,
                 }),
             }),
         };
@@ -1550,6 +1554,7 @@ mod tests {
                             youtube_url: None,
                             media: None,
                             protected_attributes: None,
+                            token_subtype: None
                         }),
                     },
                 };
@@ -1588,6 +1593,7 @@ mod tests {
                 youtube_url: None,
                 media: None,
                 protected_attributes: None,
+                token_subtype: None,
             }),
         };
 
@@ -1650,6 +1656,7 @@ mod tests {
                                 youtube_url: None,
                                 media: None,
                                 protected_attributes: None,
+                                token_subtype: None,
                             }),
                         }),
                         private_metadata: None,
@@ -1713,6 +1720,7 @@ mod tests {
                     youtube_url: None,
                     media: None,
                     protected_attributes: None,
+                    token_subtype: None,
                 }),
             }),
             private_metadata: None,


### PR DESCRIPTION
token_subtype metadata is available in the [Snip721 Referenence implementation](https://github.com/baedrik/snip721-reference-impl/blob/master/src/token.rs) and used by Stash