### PR TITLE
Feat/blanket permits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secret-toolkit"
-version = "0.10.2"
+version = "0.10.3"
 edition = "2021"
 authors = ["SCRT Labs <info@scrtlabs.com>"]
 license-file = "LICENSE"
@@ -37,16 +37,16 @@ viewing-key = ["secret-toolkit-viewing-key"]
 notification = ["secret-toolkit-notification"]
 
 [dependencies]
-secret-toolkit-crypto = { version = "0.10.2", path = "packages/crypto", optional = true }
-secret-toolkit-incubator = { version = "0.10.2", path = "packages/incubator", optional = true }
-secret-toolkit-permit = { version = "0.10.2", path = "packages/permit", optional = true }
-secret-toolkit-serialization = { version = "0.10.2", path = "packages/serialization", optional = true }
-secret-toolkit-snip20 = { version = "0.10.2", path = "packages/snip20", optional = true }
-secret-toolkit-snip721 = { version = "0.10.2", path = "packages/snip721", optional = true }
-secret-toolkit-storage = { version = "0.10.2", path = "packages/storage", optional = true }
-secret-toolkit-utils = { version = "0.10.2", path = "packages/utils", optional = true }
-secret-toolkit-viewing-key = { version = "0.10.2", path = "packages/viewing_key", optional = true }
-secret-toolkit-notification = { version = "0.10.2", path = "packages/notification", optional = true }
+secret-toolkit-crypto = { version = "0.10.3", path = "packages/crypto", optional = true }
+secret-toolkit-incubator = { version = "0.10.3", path = "packages/incubator", optional = true }
+secret-toolkit-permit = { version = "0.10.3", path = "packages/permit", optional = true }
+secret-toolkit-serialization = { version = "0.10.3", path = "packages/serialization", optional = true }
+secret-toolkit-snip20 = { version = "0.10.3", path = "packages/snip20", optional = true }
+secret-toolkit-snip721 = { version = "0.10.3", path = "packages/snip721", optional = true }
+secret-toolkit-storage = { version = "0.10.3", path = "packages/storage", optional = true }
+secret-toolkit-utils = { version = "0.10.3", path = "packages/utils", optional = true }
+secret-toolkit-viewing-key = { version = "0.10.3", path = "packages/viewing_key", optional = true }
+secret-toolkit-notification = { version = "0.10.3", path = "packages/notification", optional = true }
 
 [workspace]
 members = ["packages/*"]

--- a/packages/crypto/Cargo.toml
+++ b/packages/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secret-toolkit-crypto"
-version = "0.10.2"
+version = "0.10.3"
 edition = "2021"
 authors = ["SCRT Labs <info@scrtlabs.com>"]
 license-file = "../../LICENSE"

--- a/packages/incubator/Cargo.toml
+++ b/packages/incubator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secret-toolkit-incubator"
-version = "0.10.2"
+version = "0.10.3"
 edition = "2021"
 authors = ["SCRT Labs <info@scrtlabs.com>"]
 license-file = "../../LICENSE"
@@ -16,7 +16,7 @@ all-features = true
 [dependencies]
 serde = { workspace = true, optional = true }
 cosmwasm-std = { workspace = true, optional = true }
-secret-toolkit-serialization = { version = "0.10.2", path = "../serialization", optional = true }
+secret-toolkit-serialization = { version = "0.10.3", path = "../serialization", optional = true }
 
 [features]
 generational-store = ["secret-toolkit-serialization", "serde", "cosmwasm-std"]

--- a/packages/notification/Cargo.toml
+++ b/packages/notification/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secret-toolkit-notification"
-version = "0.10.2"
+version = "0.10.3"
 edition = "2021"
 authors = ["darwinzer0","blake-regalia"]
 license-file = "../../LICENSE"
@@ -30,6 +30,6 @@ primitive-types = { version = "0.12.2", default-features = false }
 hex = "0.4.3"
 minicbor = "0.25.1"
 
-secret-toolkit-crypto = { version = "0.10.2", path = "../crypto", features = [
+secret-toolkit-crypto = { version = "0.10.3", path = "../crypto", features = [
     "hash", "hkdf"
 ] }

--- a/packages/permit/Cargo.toml
+++ b/packages/permit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secret-toolkit-permit"
-version = "0.10.2"
+version = "0.10.3"
 edition = "2021"
 authors = ["SCRT Labs <info@scrtlabs.com>"]
 license-file = "../../LICENSE"
@@ -20,6 +20,9 @@ ripemd = { version = "0.1.3", default-features = false }
 schemars = { workspace = true }
 bech32 = "0.9.1"
 remain = "0.2.8"
-secret-toolkit-crypto = { version = "0.10.2", path = "../crypto", features = [
+secret-toolkit-crypto = { version = "0.10.3", path = "../crypto", features = [
     "hash",
 ] }
+secret-toolkit-utils = { version = "0.10.3", path = "../utils" }
+secret-toolkit-storage = { version = "0.10.3", path = "../storage" }
+

--- a/packages/permit/src/funcs.rs
+++ b/packages/permit/src/funcs.rs
@@ -1,20 +1,36 @@
-use cosmwasm_std::{to_binary, Binary, CanonicalAddr, Deps, StdError, StdResult};
-use ripemd::{Digest, Ripemd160};
+use std::u64;
 
-use crate::{Permissions, Permit, RevokedPermits, SignedPermit};
+use cosmwasm_std::{to_binary, Binary, CanonicalAddr, Deps, Env, StdError, StdResult, Timestamp};
+use ripemd::{Digest, Ripemd160};
+use secret_toolkit_utils::iso8601_utc0_to_timestamp;
+
+use crate::{Permissions, Permit, RevokedPermits, RevokedPermitsStore, SignedPermit, BLANKET_PERMIT_TOKEN};
 use bech32::{ToBase32, Variant};
 use secret_toolkit_crypto::sha_256;
 
 pub fn validate<Permission: Permissions>(
     deps: Deps,
-    storage_prefix: &str,
+    env: Env,
     permit: &Permit<Permission>,
     current_token_address: String,
     hrp: Option<&str>,
 ) -> StdResult<String> {
     let account_hrp = hrp.unwrap_or("secret");
 
-    if !permit.check_token(&current_token_address) {
+    if permit.params.allowed_tokens.contains(&BLANKET_PERMIT_TOKEN.to_string()) {
+        // using blanket permit
+        
+        // assert allowed_tokens list has an exact length of 1
+        if permit.params.allowed_tokens.len() != 1 {
+            return Err(StdError::generic_err("Blanket permits cannot contain other allowed tokens"));
+        }
+
+        // assert created field is specified
+        if permit.params.created.is_none() {
+            return Err(StdError::generic_err("Blanket permits must have a `created` time"));
+        }
+    } else if !permit.check_token(&current_token_address) {
+        // check that current token address is in allowed tokens
         return Err(StdError::generic_err(format!(
             "Permit doesn't apply to token {:?}, allowed tokens: {:?}",
             current_token_address.as_str(),
@@ -27,16 +43,75 @@ pub fn validate<Permission: Permissions>(
         )));
     }
 
+    // Convert the permit created field to a Timestamp
+    let created_timestamp = permit.params.created.clone()
+        .map(|created| 
+            iso8601_utc0_to_timestamp(&created)
+        )
+        .transpose()?;
+
+    if let Some(created) = created_timestamp {
+        // Verify that the permit was not created after the current block time
+        if created > env.block.time {
+            return Err(StdError::generic_err("Permit `created` after current block time"));
+        }
+    }
+
+    // Convert the permit expires field to a Timestamp
+    let expires_timestamp = permit.params.expires.clone()
+        .map(|created| 
+            iso8601_utc0_to_timestamp(&created)
+        )
+        .transpose()?;
+
+    if let Some(expires) = expires_timestamp {
+        // Verify that the permit did not expire before the current block time
+        if expires <= env.block.time {
+            return Err(StdError::generic_err("Permit has expired"))
+        }
+    }
+
     // Derive account from pubkey
     let pubkey = &permit.signature.pub_key.value;
 
     let base32_addr = pubkey_to_account(pubkey).0.as_slice().to_base32();
     let account: String = bech32::encode(account_hrp, base32_addr, Variant::Bech32).unwrap();
 
+    // Get the list of all revocations for this address
+    let revocations = RevokedPermits::list_revocations(deps.storage, &account)?;
+
+    // Check if there are any revocation intervals blocking all permits
+    //   TODO: An interval or segment tree might be preferable to make this more efficient for cases 
+    //         when the number of revocations is allowed to grow to a large amount.
+    for revocation in revocations {
+        // If this revocation has no `created_before` or `created_after`, then reject all permit queries
+        if revocation.interval.created_before.is_none() && revocation.interval.created_after.is_none() {
+            return Err(StdError::generic_err(
+                format!("Permits revoked by {:?}", account.as_str())
+            ));
+        }
+
+        // If the permit has a `created` field
+        if let Some(created) = created_timestamp {
+            // Revocation created before field, default 0
+            let created_before = revocation.interval.created_before.unwrap_or(Timestamp::from_nanos(0));
+
+            // Revocation created after field, default max u64
+            let created_after = revocation.interval.created_after.unwrap_or(Timestamp::from_nanos(u64::MAX));
+
+            // If the permit's `created` field falls in between created after and created before, then reject it
+            if created > created_after || created < created_before {
+                return Err(StdError::generic_err(
+                    format!("Permits created at {:?} revoked by account {:?}", created, account.as_str())
+                ));                
+            }         
+        }
+    }
+
     // Validate permit_name
     let permit_name = &permit.params.permit_name;
     let is_permit_revoked =
-        RevokedPermits::is_permit_revoked(deps.storage, storage_prefix, &account, permit_name);
+        RevokedPermits::is_permit_revoked(deps.storage, &account, permit_name);
     if is_permit_revoked {
         return Err(StdError::generic_err(format!(
             "Permit {:?} was revoked by account {:?}",
@@ -73,7 +148,7 @@ pub fn pubkey_to_account(pubkey: &Binary) -> CanonicalAddr {
 mod tests {
     use super::*;
     use crate::{PermitParams, PermitSignature, PubKey, TokenPermissions};
-    use cosmwasm_std::testing::mock_dependencies;
+    use cosmwasm_std::testing::{mock_dependencies, mock_env};
 
     #[test]
     fn test_verify_permit() {
@@ -88,7 +163,9 @@ mod tests {
                 allowed_tokens: vec![token.clone()],
                 permit_name: "memo_secret1rf03820fp8gngzg2w02vd30ns78qkc8rg8dxaq".to_string(),
                 chain_id: "pulsar-2".to_string(),
-                permissions: vec![TokenPermissions::History]
+                permissions: vec![TokenPermissions::History],
+                created: None,
+                expires: None,
             },
             signature: PermitSignature {
                 pub_key: PubKey {
@@ -99,9 +176,11 @@ mod tests {
             }
         };
 
+        let env = mock_env();
+
         let address = validate::<_>(
             deps.as_ref(),
-            "test",
+            env,
             &permit,
             token.clone(),
             Some("secret"),
@@ -113,7 +192,15 @@ mod tests {
             "secret1399pyvvk3hvwgxwt3udkslsc5jl3rqv4yshfrl".to_string()
         );
 
-        let address = validate::<_>(deps.as_ref(), "test", &permit, token, Some("cosmos")).unwrap();
+        let env = mock_env();
+
+        let address = validate::<_>(
+            deps.as_ref(), 
+            env, 
+            &permit, 
+            token, 
+            Some("cosmos")
+        ).unwrap();
 
         assert_eq!(
             address,

--- a/packages/permit/src/funcs.rs
+++ b/packages/permit/src/funcs.rs
@@ -1,6 +1,6 @@
 use std::u64;
 
-use cosmwasm_std::{to_binary, Binary, CanonicalAddr, Deps, Env, StdError, StdResult, Timestamp, Uint64};
+use cosmwasm_std::{to_binary, Binary, CanonicalAddr, Deps, Env, StdError, StdResult, Uint64};
 use ripemd::{Digest, Ripemd160};
 use secret_toolkit_utils::iso8601_utc0_to_timestamp;
 
@@ -148,7 +148,7 @@ pub fn pubkey_to_account(pubkey: &Binary) -> CanonicalAddr {
 mod tests {
     use super::*;
     use crate::{PermitParams, PermitSignature, PubKey, TokenPermissions};
-    use cosmwasm_std::testing::{mock_dependencies, mock_env};
+    use cosmwasm_std::{testing::{mock_dependencies, mock_env}, Timestamp};
 
     #[test]
     fn test_verify_permit() {

--- a/packages/permit/src/funcs.rs
+++ b/packages/permit/src/funcs.rs
@@ -10,7 +10,7 @@ use secret_toolkit_crypto::sha_256;
 
 pub fn validate<Permission: Permissions>(
     deps: Deps,
-    env: Env,
+    env: &Env,
     permit: &Permit<Permission>,
     current_token_address: String,
     hrp: Option<&str>,
@@ -181,7 +181,7 @@ mod tests {
 
         let address = validate::<_>(
             deps.as_ref(),
-            env,
+            &env,
             &permit,
             token.clone(),
             Some("secret"),
@@ -197,7 +197,7 @@ mod tests {
 
         let address = validate::<_>(
             deps.as_ref(), 
-            env, 
+            &env, 
             &permit, 
             token, 
             Some("cosmos")
@@ -249,7 +249,7 @@ mod tests {
         // secret16v498l7d335wlzxpzg0mwkucrszdlza008dhc9
         let address = validate::<_>(
             deps.as_ref(),
-            env,
+            &env,
             &permit,
             token.clone(),
             Some("secret"),
@@ -267,7 +267,7 @@ mod tests {
 
         let address = validate::<_>(
             deps.as_ref(),
-            env,
+            &env,
             &permit,
             token.clone(),
             Some("secret"),
@@ -282,7 +282,7 @@ mod tests {
 
         let address = validate::<_>(
             deps.as_ref(),
-            env,
+            &env,
             &permit,
             token.clone(),
             Some("secret"),
@@ -331,7 +331,7 @@ mod tests {
         // secret16v498l7d335wlzxpzg0mwkucrszdlza008dhc9
         let address = validate::<_>(
             deps.as_ref(),
-            env,
+            &env,
             &permit,
             token.clone(),
             Some("secret"),
@@ -349,7 +349,7 @@ mod tests {
 
         let address = validate::<_>(
             deps.as_ref(),
-            env,
+            &env,
             &permit,
             token.clone(),
             Some("secret"),
@@ -364,7 +364,7 @@ mod tests {
 
         let address = validate::<_>(
             deps.as_ref(),
-            env,
+            &env,
             &permit,
             token.clone(),
             Some("secret"),
@@ -404,7 +404,7 @@ mod tests {
         // secret16v498l7d335wlzxpzg0mwkucrszdlza008dhc9
         let address = validate::<_>(
             deps.as_ref(),
-            env,
+            &env,
             &permit,
             token.clone(),
             Some("secret"),
@@ -444,7 +444,7 @@ mod tests {
         // secret16v498l7d335wlzxpzg0mwkucrszdlza008dhc9
         let address = validate::<_>(
             deps.as_ref(),
-            env,
+            &env,
             &permit,
             token.clone(),
             Some("secret"),

--- a/packages/permit/src/state.rs
+++ b/packages/permit/src/state.rs
@@ -138,15 +138,15 @@ pub trait RevokedPermitsStore<'a> {
 /// An interval over which all permits will be rejected
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct AllRevokedInterval {
-    pub created_before: Option<Timestamp>,
-    pub created_after: Option<Timestamp>,
+    pub created_before: Option<Uint64>,
+    pub created_after: Option<Uint64>,
 }
 
 impl AllRevokedInterval {
     fn into_stored(&self) -> StoredAllRevokedInterval {
         StoredAllRevokedInterval { 
-            created_before: self.created_before.and_then(|cb| Some(cb.seconds())), 
-            created_after: self.created_after.and_then(|ca| Some(ca.seconds())), 
+            created_before: self.created_before.and_then(|cb| Some(cb.u64())), 
+            created_after: self.created_after.and_then(|ca| Some(ca.u64())), 
         }
     }
 }
@@ -161,8 +161,8 @@ pub struct StoredAllRevokedInterval {
 impl StoredAllRevokedInterval {
     fn to_humanized(&self) -> AllRevokedInterval {
         AllRevokedInterval {
-            created_before: self.created_before.and_then(|cb| Some(Timestamp::from_seconds(cb))), 
-            created_after: self.created_after.and_then(|ca| Some(Timestamp::from_seconds(ca))),
+            created_before: self.created_before.and_then(|cb| Some(Uint64::from(cb))), 
+            created_after: self.created_after.and_then(|ca| Some(Uint64::from(ca))),
         }
     }
 }

--- a/packages/permit/src/state.rs
+++ b/packages/permit/src/state.rs
@@ -122,7 +122,7 @@ pub trait RevokedPermitsStore<'a> {
             .filter_map(|r| {
                 match r {
                     Ok(r) => Some(AllRevocation {
-                        id: Uint64::from(r.0),
+                        revocation_id: Uint64::from(r.0),
                         interval: r.1.clone()
                     }),
                     Err(_) => None
@@ -145,6 +145,6 @@ pub struct AllRevokedInterval {
 /// Revocation id and interval data struct
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct AllRevocation {
-    pub id: Uint64,
+    pub revocation_id: Uint64,
     pub interval: AllRevokedInterval,
 }

--- a/packages/permit/src/state.rs
+++ b/packages/permit/src/state.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{StdError, StdResult, Storage, Timestamp, Uint64};
+use cosmwasm_std::{StdError, StdResult, Storage, Uint64};
 use schemars::JsonSchema;
 use secret_toolkit_storage::{Item, Keymap};
 use serde::{Deserialize, Serialize};

--- a/packages/permit/src/state.rs
+++ b/packages/permit/src/state.rs
@@ -1,32 +1,147 @@
-use cosmwasm_std::Storage;
+use cosmwasm_std::{StdError, StdResult, Storage, Timestamp, Uint64};
+use schemars::JsonSchema;
+use secret_toolkit_storage::{Item, Keymap};
+use serde::{Deserialize, Serialize};
 
+/// This is the default implementation of the revoked permits store, using the "revoked_permits"
+/// storage prefix for named permits and "all_revoked_permits" for revoked blanket permits.
+/// It also sets the maximum number of all permit revocations to 10 by default.
+///
+/// You can use another storage location by implementing `RevokedPermitsStore` for your own type.
 pub struct RevokedPermits;
 
-impl RevokedPermits {
-    pub fn is_permit_revoked(
-        storgae: &dyn Storage,
-        storage_prefix: &str,
+impl<'a> RevokedPermitsStore<'a> for RevokedPermits {
+    const NAMED_REVOKED_PERMITS_PREFIX: &'static [u8] = b"revoked_permits";
+    const ALL_REVOKED_PERMITS: Keymap<'a, u64, AllRevokedInterval> = Keymap::new(b"all_revoked_permits");
+    const ALL_REVOKED_NEXT_ID: Item<'a, u64> = Item::new(b"all_revoked_permits_serial_id");
+    const MAX_ALL_REVOKED_INTERVALS: u8 = 10;
+}
+
+/// A trait describing the interface of a RevokedPermits store/vault.
+///
+/// It includes a default implementation that only requires specifying where in the storage
+/// the keys should be held.
+pub trait RevokedPermitsStore<'a> {
+    const NAMED_REVOKED_PERMITS_PREFIX: &'static [u8];
+    const ALL_REVOKED_PERMITS: Keymap<'a, u64, AllRevokedInterval>;
+    const ALL_REVOKED_NEXT_ID: Item<'a, u64>;
+    const MAX_ALL_REVOKED_INTERVALS: u8;
+
+    /// returns a bool indicating if a named permit is revoked
+    fn is_permit_revoked(
+        storage: &dyn Storage,
         account: &str,
         permit_name: &str,
     ) -> bool {
-        let storage_key = storage_prefix.to_string() + account + permit_name;
+        let mut storage_key = Vec::new();
+        storage_key.extend_from_slice(Self::NAMED_REVOKED_PERMITS_PREFIX);
+        storage_key.extend_from_slice(account.as_bytes());
+        storage_key.extend_from_slice(permit_name.as_bytes());
 
-        storgae.get(storage_key.as_bytes()).is_some()
+        storage.get(&storage_key).is_some()
     }
 
-    pub fn revoke_permit(
+    /// revokes a named permit permanently
+    fn revoke_permit(
         storage: &mut dyn Storage,
-        storage_prefix: &str,
         account: &str,
         permit_name: &str,
     ) {
-        let storage_key = storage_prefix.to_string() + account + permit_name;
+        let mut storage_key = Vec::new();
+        storage_key.extend_from_slice(Self::NAMED_REVOKED_PERMITS_PREFIX);
+        storage_key.extend_from_slice(account.as_bytes());
+        storage_key.extend_from_slice(permit_name.as_bytes());
 
         // Since cosmwasm V1.0 it's not possible to set an empty value, hence set some unimportant
         // character '_'
         //
         // Here is the line of the new panic that was added when trying to insert an empty value:
         // https://github.com/scrtlabs/cosmwasm/blob/f7e2b1dbf11e113e258d796288752503a5012367/packages/std/src/storage.rs#L30
-        storage.set(storage_key.as_bytes(), "_".as_bytes())
+        storage.set(&storage_key, "_".as_bytes())
     }
+
+    /// revokes all permits created after and before
+    fn revoke_all_permits(
+        storage: &mut dyn Storage,
+        account: &str,
+        interval: &AllRevokedInterval,
+    ) -> StdResult<Uint64> {
+        // get the revocations store for this account
+        let all_revocations_store = Self::ALL_REVOKED_PERMITS.add_suffix(account.as_bytes());
+
+        // check that maximum number of revocations has not been met
+        if all_revocations_store.get_len(storage)? >= Self::MAX_ALL_REVOKED_INTERVALS.into() {
+            return Err(StdError::generic_err(
+                format!("Maximum number of permit revocations ({}) has been met", Self::MAX_ALL_REVOKED_INTERVALS)
+            ));
+        }
+
+        // get the next id store for this account
+        let next_id_store = Self::ALL_REVOKED_NEXT_ID.add_suffix(account.as_bytes());
+
+        // get the next id
+        let next_id = next_id_store.may_load(storage)?.unwrap_or_default();
+
+        // store the revocation
+        all_revocations_store.insert(storage, &next_id, interval)?;
+
+        // increment next id
+        next_id_store.save(storage, &(next_id.wrapping_add(1)))?;
+
+        Ok(Uint64::from(next_id))
+    }
+
+    /// deletes the permit revocation with the given id for this account
+    fn delete_revocation(
+        storage: &mut dyn Storage,
+        account: &str,
+        id: Uint64,
+    ) -> StdResult<()> {
+        // get the revocations store for this account
+        let all_revocations_store = Self::ALL_REVOKED_PERMITS.add_suffix(account.as_bytes());
+
+        // remove the permit revocation with the given id
+        all_revocations_store.remove(storage, &id.u64())
+    }
+
+    /// lists all the revocations for the account
+    /// returns a vec of revocations
+    fn list_revocations(
+        storage: &dyn Storage,
+        account: &str,
+    ) -> StdResult<Vec<AllRevocation>> {
+        // get the revocations store for this account
+        let all_revocations_store = Self::ALL_REVOKED_PERMITS.add_suffix(account.as_bytes());
+
+        // select elements and convert to AllRevocation structs
+        let result = all_revocations_store
+            .iter(storage)?
+            .filter_map(|r| {
+                match r {
+                    Ok(r) => Some(AllRevocation {
+                        id: Uint64::from(r.0),
+                        interval: r.1.clone()
+                    }),
+                    Err(_) => None
+                }
+            })
+            .collect();
+
+        Ok(result)
+    }
+
+}
+
+/// An interval over which all permits will be rejected
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+pub struct AllRevokedInterval {
+    pub created_before: Option<Timestamp>,
+    pub created_after: Option<Timestamp>,
+}
+
+/// Revocation id and interval data struct
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+pub struct AllRevocation {
+    pub id: Uint64,
+    pub interval: AllRevokedInterval,
 }

--- a/packages/permit/src/state.rs
+++ b/packages/permit/src/state.rs
@@ -167,9 +167,9 @@ pub trait RevokedPermitsStore<'a> {
             })
             .collect();
 
-        // check if there is an all time revocation and add that as well
-        let all_time_revoked_store = Self::ALL_TIME_REVOKED_ALL.add_suffix(account.as_bytes());
-        if all_time_revoked_store.may_load(storage)?.unwrap_or_default() {
+        // check if there is an all time revocation 
+        if Self::is_all_time_revoked(storage, account)? {
+            // add that to the result
             result.push(AllRevocation {
                 revocation_id: REVOKED_ALL.to_string(),
                 interval: AllRevokedInterval { 
@@ -178,6 +178,16 @@ pub trait RevokedPermitsStore<'a> {
                 }
             });
         }
+
+        Ok(result)
+    }
+
+    /// returns bool if queries are all time revoked for this account
+    fn is_all_time_revoked(storage: &dyn Storage, account: &str) -> StdResult<bool> {
+        // get the all time revoked store for this account
+        let all_time_revoked_store = Self::ALL_TIME_REVOKED_ALL.add_suffix(account.as_bytes());
+
+        let result = all_time_revoked_store.may_load(storage)?.unwrap_or_default();
 
         Ok(result)
     }

--- a/packages/permit/src/structs.rs
+++ b/packages/permit/src/structs.rs
@@ -7,6 +7,7 @@ use crate::pubkey_to_account;
 use cosmwasm_std::{Binary, CanonicalAddr, Uint128};
 
 pub const BLANKET_PERMIT_TOKEN: &str = "ANY_TOKEN";
+pub const REVOKED_ALL: &str = "REVOKED_ALL";
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]

--- a/packages/permit/src/structs.rs
+++ b/packages/permit/src/structs.rs
@@ -166,7 +166,9 @@ impl<Permission: Permissions> PermitMsg<Permission> {
 #[serde(rename_all = "snake_case")]
 pub struct PermitContent<Permission: Permissions = TokenPermissions> {
     pub allowed_tokens: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub created: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub expires: Option<String>,
     #[serde(bound = "")]
     pub permissions: Vec<Permission>,

--- a/packages/permit/src/structs.rs
+++ b/packages/permit/src/structs.rs
@@ -6,6 +6,8 @@ use serde::{Deserialize, Serialize};
 use crate::pubkey_to_account;
 use cosmwasm_std::{Binary, CanonicalAddr, Uint128};
 
+pub const BLANKET_PERMIT_TOKEN: &str = "ANY_TOKEN";
+
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct Permit<Permission: Permissions = TokenPermissions> {
@@ -16,7 +18,7 @@ pub struct Permit<Permission: Permissions = TokenPermissions> {
 
 impl<Permission: Permissions> Permit<Permission> {
     pub fn check_token(&self, token: &str) -> bool {
-        self.params.allowed_tokens.contains(&token.to_string())
+        self.params.allowed_tokens.contains(&token.to_string()) 
     }
 
     pub fn check_permission(&self, permission: &Permission) -> bool {
@@ -32,6 +34,8 @@ pub struct PermitParams<Permission: Permissions = TokenPermissions> {
     pub chain_id: String,
     #[serde(bound = "")]
     pub permissions: Vec<Permission>,
+    pub created: Option<String>,
+    pub expires: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
@@ -162,6 +166,8 @@ impl<Permission: Permissions> PermitMsg<Permission> {
 #[serde(rename_all = "snake_case")]
 pub struct PermitContent<Permission: Permissions = TokenPermissions> {
     pub allowed_tokens: Vec<String>,
+    pub created: Option<String>,
+    pub expires: Option<String>,
     #[serde(bound = "")]
     pub permissions: Vec<Permission>,
     pub permit_name: String,
@@ -171,6 +177,8 @@ impl<Permission: Permissions> PermitContent<Permission> {
     pub fn from_params(params: &PermitParams<Permission>) -> Self {
         Self {
             allowed_tokens: params.allowed_tokens.clone(),
+            created: params.created.clone(),
+            expires: params.expires.clone(),
             permit_name: params.permit_name.clone(),
             permissions: params.permissions.clone(),
         }

--- a/packages/serialization/Cargo.toml
+++ b/packages/serialization/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secret-toolkit-serialization"
-version = "0.10.2"
+version = "0.10.3"
 edition = "2021"
 authors = ["SCRT Labs <info@scrtlabs.com>"]
 license-file = "../../LICENSE"

--- a/packages/snip20/Cargo.toml
+++ b/packages/snip20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secret-toolkit-snip20"
-version = "0.10.2"
+version = "0.10.3"
 edition = "2021"
 authors = ["SCRT Labs <info@scrtlabs.com>"]
 license-file = "../../LICENSE"
@@ -17,4 +17,4 @@ all-features = true
 serde = { workspace = true }
 schemars = { workspace = true }
 cosmwasm-std = { workspace = true }
-secret-toolkit-utils = { version = "0.10.2", path = "../utils" }
+secret-toolkit-utils = { version = "0.10.3", path = "../utils" }

--- a/packages/snip721/Cargo.toml
+++ b/packages/snip721/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secret-toolkit-snip721"
-version = "0.10.2"
+version = "0.10.3"
 edition = "2021"
 authors = ["SCRT Labs <info@scrtlabs.com>"]
 license-file = "../../LICENSE"
@@ -17,4 +17,4 @@ all-features = true
 serde = { workspace = true }
 schemars = { workspace = true }
 cosmwasm-std = { workspace = true }
-secret-toolkit-utils = { version = "0.10.2", path = "../utils" }
+secret-toolkit-utils = { version = "0.10.3", path = "../utils" }

--- a/packages/storage/Cargo.toml
+++ b/packages/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secret-toolkit-storage"
-version = "0.10.2"
+version = "0.10.3"
 edition = "2021"
 authors = ["SCRT Labs <info@scrtlabs.com>"]
 license-file = "../../LICENSE"
@@ -17,4 +17,4 @@ all-features = true
 serde = { workspace = true }
 cosmwasm-std = { workspace = true }
 cosmwasm-storage = { workspace = true }
-secret-toolkit-serialization = { version = "0.10.2", path = "../serialization" }
+secret-toolkit-serialization = { version = "0.10.3", path = "../serialization" }

--- a/packages/utils/Cargo.toml
+++ b/packages/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secret-toolkit-utils"
-version = "0.10.2"
+version = "0.10.3"
 edition = "2021"
 authors = ["SCRT Labs <info@scrtlabs.com>"]
 license-file = "../../LICENSE"
@@ -18,3 +18,5 @@ serde = { workspace = true }
 schemars = { workspace = true }
 cosmwasm-std = { workspace = true }
 cosmwasm-storage = { workspace = true }
+
+chrono = "0.4"

--- a/packages/utils/Cargo.toml
+++ b/packages/utils/Cargo.toml
@@ -19,4 +19,4 @@ schemars = { workspace = true }
 cosmwasm-std = { workspace = true }
 cosmwasm-storage = { workspace = true }
 
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false }

--- a/packages/utils/src/datetime.rs
+++ b/packages/utils/src/datetime.rs
@@ -1,0 +1,23 @@
+use chrono::{DateTime, Utc};
+use cosmwasm_std::{StdError, StdResult, Timestamp};
+
+
+/// Converts an ISO 8601 date-time string in Zulu (UTC+0) format to a Timestamp.
+/// 
+/// String format: {YYYY}-{MM}-{DD}T{hh}:{mm}:{ss}.{uuu}Z
+/// 
+/// * `iso8601_str` - The ISO 8601 date-time string to convert.
+/// 
+/// Returns StdResult<Timestamp>
+pub fn iso8601_utc0_to_timestamp(iso8601_str: &str) -> StdResult<Timestamp> {
+    let Ok(datetime) = iso8601_str.parse::<DateTime<Utc>>() else {
+        return Err(StdError::generic_err("ISO 8601 string could not be parsed"));
+    };
+
+    // Verify the timezone is UTC (Zulu time)
+    if iso8601_str.ends_with("Z") {
+        Ok(Timestamp::from_seconds(datetime.timestamp().try_into().unwrap_or_default()))
+    } else {
+        Err(StdError::generic_err("ISO 8601 string not in Zulu (UTC+0)"))
+    }
+}

--- a/packages/utils/src/datetime.rs
+++ b/packages/utils/src/datetime.rs
@@ -22,6 +22,30 @@ pub fn iso8601_utc0_to_timestamp(iso8601_str: &str) -> StdResult<Timestamp> {
     }
 }
 
+/// Converts an ISO 8601 date-time string in Zulu (UTC+0) format to seconds.
+/// 
+/// String format: {YYYY}-{MM}-{DD}T{hh}:{mm}:{ss}.{uuu}Z
+/// 
+/// * `iso8601_str` - The ISO 8601 date-time string to convert.
+/// 
+/// Returns StdResult<u64>
+pub fn iso8601_utc0_to_seconds(iso8601_str: &str) -> StdResult<u64> {
+    let Ok(datetime) = iso8601_str.parse::<DateTime<Utc>>() else {
+        return Err(StdError::generic_err("ISO 8601 string could not be parsed"));
+    };
+
+    // Verify the timezone is UTC (Zulu time)
+    if iso8601_str.ends_with("Z") {
+        let seconds = datetime.timestamp();
+        if seconds < 0 {
+            return Err(StdError::generic_err("Date time before January 1, 1970 0:00:00 UTC not supported"))
+        }
+        Ok(seconds as u64)
+    } else {
+        Err(StdError::generic_err("ISO 8601 string not in Zulu (UTC+0)"))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::iso8601_utc0_to_timestamp;
@@ -30,6 +54,7 @@ mod tests {
     fn test_iso8601_utc0_to_timestamp() {
         let dt_string = "2024-12-17T16:59:00.000Z";
         let timestamp = iso8601_utc0_to_timestamp(dt_string).unwrap();
+        println!("{:?}", timestamp);
         assert_eq!(timestamp.nanos(), 1734454740000000000);
 
         let dt_string = "2024-12-17T16:59:00.000";

--- a/packages/utils/src/datetime.rs
+++ b/packages/utils/src/datetime.rs
@@ -21,3 +21,23 @@ pub fn iso8601_utc0_to_timestamp(iso8601_str: &str) -> StdResult<Timestamp> {
         Err(StdError::generic_err("ISO 8601 string not in Zulu (UTC+0)"))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::iso8601_utc0_to_timestamp;
+
+    #[test]
+    fn test_iso8601_utc0_to_timestamp() {
+        let dt_string = "2024-12-17T16:59:00.000Z";
+        let timestamp = iso8601_utc0_to_timestamp(dt_string).unwrap();
+        assert_eq!(timestamp.nanos(), 1734454740000000000);
+
+        let dt_string = "2024-12-17T16:59:00.000";
+        let timestamp = iso8601_utc0_to_timestamp(dt_string);
+        assert!(timestamp.is_err(), "datetime string without Z Ok: {:?}", timestamp);
+
+        let dt_string = "not a datetime";
+        let timestamp = iso8601_utc0_to_timestamp(dt_string);
+        assert!(timestamp.is_err(), "invalid datetime string Ok: {:?}", timestamp);
+    }
+}

--- a/packages/utils/src/lib.rs
+++ b/packages/utils/src/lib.rs
@@ -4,6 +4,8 @@ pub mod calls;
 pub mod feature_toggle;
 pub mod padding;
 pub mod types;
+pub mod datetime;
 
 pub use calls::*;
 pub use padding::*;
+pub use datetime::*;

--- a/packages/viewing_key/Cargo.toml
+++ b/packages/viewing_key/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secret-toolkit-viewing-key"
-version = "0.10.2"
+version = "0.10.3"
 edition = "2021"
 authors = ["SCRT Labs <info@scrtlabs.com>"]
 license-file = "../../LICENSE"
@@ -20,8 +20,8 @@ base64 = "0.21.0"
 subtle = { version = "2.2.3", default-features = false }
 cosmwasm-std = { workspace = true }
 cosmwasm-storage = { workspace = true }
-secret-toolkit-crypto = { version = "0.10.2", path = "../crypto", features = [
+secret-toolkit-crypto = { version = "0.10.3", path = "../crypto", features = [
     "hash",
     "rand",
 ] }
-secret-toolkit-utils = { version = "0.10.2", path = "../utils" }
+secret-toolkit-utils = { version = "0.10.3", path = "../utils" }


### PR DESCRIPTION
This code introduces a backwards-compatible extension to the permit package that adds "blanket" permits, which allow the permit holder to use them with any compatible token. 

The spec for blanket permits can be found here: https://hackmd.io/5TulfqveRKuYdO802ro-bg

Additionally, it adds datetime functions to the utils package and bumps the secret toolkit version number to 0.10.3.